### PR TITLE
Typo in VSCode Configuration File

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Add to your VSCode MCP configuration:
 				"mcp_kql_server"
 			],
 			"type": "stdio"
-		},
+		}
 }
 ```
 


### PR DESCRIPTION
remove the trailing comma after the closing brace of "MCP-kql-server".
JSON doesn’t allow trailing commas — otherwise VS Code may fail to parse the file.