### PR TITLE
fix: align v2.1.1 runtime, docs, and CI validation

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -5,18 +5,18 @@ Use this checklist when preparing a new release.
 ## Pre-Release Steps
 
 ### 1. Update Version Numbers
-Update version in all files to the new version (e.g., `2.1.0`):
+Update version in all current-release files to the new version (e.g., `2.1.1`):
 
-- [ ] `pyproject.toml` - line 3: `version = "2.1.0"`
-- [ ] `mcp_kql_server/__init__.py` - line 22: `__version__ = "2.1.0"`
-- [ ] `mcp_kql_server/constants.py` - line 19: `__version__ = "2.1.0"`
-- [ ] `mcp_kql_server/constants.py` - line 88: `FASTAPI_VERSION = "2.1.0"`
-- [ ] `server.json` - line 5: `"version": "2.1.0"`
-- [ ] `server.json` - line 10: `"version": "2.1.0"` (in packages array)
+- [ ] `pyproject.toml` - line 3: `version = "2.1.1"`
+- [ ] `mcp_kql_server/__init__.py` - line 22: `__version__ = "2.1.1"`
+- [ ] `mcp_kql_server/constants.py` - line 19: `__version__ = "2.1.1"`
+- [ ] `mcp_kql_server/constants.py` - line 88: `FASTAPI_VERSION = "2.1.1"`
+- [ ] `server.json` - line 5: `"version": "2.1.1"`
+- [ ] `server.json` - line 10: `"version": "2.1.1"` (in packages array)
 
 **Quick version bump:**
 ```bash
-python .github/bump_version.py 2.0.9 2.1.0
+python .github/bump_version.py 2.1.0 2.1.1
 ```
 
 ### 2. Update Release Notes
@@ -33,7 +33,7 @@ ruff check .
 pylint mcp_kql_server/
 
 # Run tests
-pytest tests/ -v
+python -m pytest -q
 
 # Verify version consistency
 python -c "import tomli; print(f'pyproject.toml: {tomli.load(open(\"pyproject.toml\", \"rb\"))[\"project\"][\"version\"]}')"
@@ -48,7 +48,7 @@ python -m build
 # Test installation in virtual environment
 python -m venv test_env
 test_env\Scripts\activate
-pip install dist/mcp_kql_server-2.1.0-py3-none-any.whl
+pip install dist/mcp_kql_server-2.1.1-py3-none-any.whl
 # Test the package
 python -c "from mcp_kql_server import __version__; print(f'Version: {__version__}')"
 deactivate
@@ -60,7 +60,7 @@ rm -r test_env
 ### 5. Commit Changes
 ```bash
 git add .
-git commit -m "Bump version to 2.1.0"
+git commit -m "Bump version to 2.1.1"
 git push origin main
 ```
 
@@ -76,8 +76,8 @@ twine upload dist/*
 ### 7. Create GitHub Release
 ```bash
 # Create and push tag
-git tag v2.1.0
-git push origin v2.1.0
+git tag v2.1.1
+git push origin v2.1.1
 ```
 
 ### 8. Verify Automated Publishing
@@ -127,7 +127,6 @@ Ensure these files are updated/present for each release:
 - [ ] `mcp_kql_server/performance.py` - Performance utilities
 - [ ] `mcp_kql_server/utils.py` - Utilities
 - [ ] `mcp_kql_server/ai_prompts.py` - AI prompts
-- [ ] `mcp_kql_server/mcp_registry.py` - Registry support
 - [ ] `mcp_kql_server/py.typed` - Type marker
 
 ### Documentation Files
@@ -171,14 +170,14 @@ Ensure these files are updated/present for each release:
 Use the Python script for automatic version bumping:
 ```bash
 # Update all version files automatically
-python .github/bump_version.py 2.0.9 2.1.0
+python .github/bump_version.py 2.1.0 2.1.1
 ```
 
 Or use this bash script for manual updates:
 ```bash
 # Save this as bump_version.sh
-OLD_VERSION="2.0.9"
-NEW_VERSION="2.1.0"
+OLD_VERSION="2.1.0"
+NEW_VERSION="2.1.1"
 
 # Update all version files
 sed -i "s/$OLD_VERSION/$NEW_VERSION/g" pyproject.toml
@@ -193,7 +192,7 @@ echo "Remember to update RELEASE_NOTES.md manually!"
 ## Version History Template
 
 ```markdown
-## 📦 **v2.1.0 - [Release Title]**
+## 📦 **v2.1.1 - [Release Title]**
 
 > **[Brief Description]** 🚀
 
@@ -202,7 +201,7 @@ echo "Remember to update RELEASE_NOTES.md manually!"
 **Email**: arjuntrivedi42@yahoo.com
 **Repository**: https://github.com/4R9UN/mcp-kql-server
 
-### 🚀 **What's New in v2.1.0**
+### 🚀 **What's New in v2.1.1**
 
 #### **1. [Feature Category]**
 - **Feature 1**: Description

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install -e ".[dev]"
+    - name: Run tests with coverage
+      run: |
+        python -m pytest --cov=mcp_kql_server --cov-report=term-missing --cov-report=xml -q
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-report
+        path: coverage.xml
 
   publish-pypi:
     name: Publish to PyPI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,22 +71,25 @@ source .venv/bin/activate
 ### Install Dependencies
 
 ```bash
-# Install in development mode with all dependencies
+# Install in development mode with the repo's source-of-truth metadata
 pip install -e ".[dev]"
 
-# Or install from requirements
-pip install -r requirements.txt
-pip install pytest pytest-cov pytest-asyncio pylint
+# Optional: runtime-only install without contributor tooling
+pip install -e .
 ```
+
+`pyproject.toml` is the single source of truth for package metadata and contributor tooling.
+Use `requirements.txt` only when you specifically need the legacy runtime dependency snapshot.
 
 ### Verify Installation
 
 ```bash
 # Run tests to verify setup
-python -m pytest tests/ -v
+python -m pytest -q
 
 # Check code quality
 python -m pylint mcp_kql_server/
+ruff check .
 ```
 
 ---
@@ -161,12 +164,13 @@ Closes #42
 
 2. **Run all tests:**
    ```bash
-   python -m pytest tests/ -v --cov=mcp_kql_server
+    python -m pytest --cov=mcp_kql_server -q
    ```
 
 3. **Check code quality:**
    ```bash
    python -m pylint mcp_kql_server/ --disable=C0301,C0114,C0115,C0116
+    ruff check .
    ```
 
 4. **Update documentation** if needed

--- a/Example/mcp_kql_usage_examples.py
+++ b/Example/mcp_kql_usage_examples.py
@@ -1,58 +1,35 @@
 #!/usr/bin/env python3
-"""
-MCP KQL Server Usage Examples
-
-This file demonstrates how to use the MCP KQL Server tools
-for various KQL query scenarios and schema management.
-"""
+"""Current MCP KQL Server usage examples for the v2.1.1 tool contract."""
 
 import json
 from typing import Any, Dict
 
-# ============================================================================
-# EXAMPLE 1: Basic KQL Query Execution
-# ============================================================================
-
-
 def example_basic_query() -> Dict[str, Any]:
-    """Execute a basic KQL query with visualization."""
+    """Execute a basic KQL query with the current tool shape."""
 
     request = {
-        "tool": "kql_execute",
+        "tool": "execute_kql_query",
         "input": {
-            "query": """
-                cluster('help.kusto.windows.net')
-                .database('Samples')
-                .StormEvents
-                | where State == 'TEXAS'
-                | where StartTime >= datetime(2007-01-01)
-                | summarize EventCount = count() by EventType
-                | top 5 by EventCount desc
-            """,
-            "visualize": True,
-            "use_schema_context": True,
+            "query": "StormEvents | where State == 'TEXAS' | where StartTime >= datetime(2007-01-01) | summarize EventCount = count() by EventType | top 5 by EventCount desc",
+            "cluster_url": "https://help.kusto.windows.net",
+            "database": "Samples",
+            "output_format": "table",
         },
     }
 
     # Expected response structure:
     expected_response = {
-        "status": "success",
-        "result": {
-            "columns": ["EventType", "EventCount"],
-            "rows": [
-                ["Hail", 742],
-                ["Thunderstorm Wind", 568],
-                ["Flash Flood", 289],
-                ["Tornado", 187],
-                ["Heavy Rain", 156],
-            ],
-            "row_count": 5,
-            "visualization": "| EventType | EventCount |\n|---|---|\n| Hail | 742 |\n...",
-            "schema_context": [
-                "Table: StormEvents - Contains storm and weather event data...",
-                "Key columns: StartTime, EndTime, State, EventType, DamageProperty",
-            ],
-        },
+        "success": True,
+        "query": "StormEvents | where State == 'TEXAS' | where StartTime >= datetime(2007-01-01) | summarize EventCount = count() by EventType | top 5 by EventCount desc",
+        "row_count": 5,
+        "columns": ["EventType", "EventCount"],
+        "data": [
+            ["Hail", 742],
+            ["Thunderstorm Wind", 568],
+            ["Flash Flood", 289],
+            ["Tornado", 187],
+            ["Heavy Rain", 156],
+        ],
     }
 
     return {
@@ -62,38 +39,16 @@ def example_basic_query() -> Dict[str, Any]:
     }
 
 
-# ============================================================================
-# EXAMPLE 2: Complex JSON Processing Query
-# ============================================================================
-
-
 def example_json_processing() -> Dict[str, Any]:
-    """Execute a complex query with JSON parsing and extraction."""
+    """Execute a complex query against a specific cluster and database."""
 
     request = {
-        "tool": "kql_execute",
+        "tool": "execute_kql_query",
         "input": {
-            "query": """
-                cluster('mycluster.kusto.windows.net')
-                .database('ApplicationLogs')
-                .Events
-                | where Timestamp >= ago(24h)
-                | extend EventProps = parse_json(Properties)
-                | extend UserId = tostring(EventProps.userId)
-                | extend SessionId = tostring(EventProps.sessionId)
-                | extend ActionType = tostring(EventProps.actionType)
-                | where isnotempty(UserId)
-                | summarize
-                    UniqueActions = dcount(ActionType),
-                    TotalEvents = count(),
-                    LastActivity = max(Timestamp)
-                  by UserId
-                | where UniqueActions >= 5
-                | order by TotalEvents desc
-                | limit 10
-            """,
-            "visualize": True,
-            "use_schema_context": True,
+            "query": "Events | where Timestamp >= ago(24h) | extend EventProps = parse_json(Properties) | extend UserId = tostring(EventProps.userId) | extend SessionId = tostring(EventProps.sessionId) | extend ActionType = tostring(EventProps.actionType) | where isnotempty(UserId) | summarize UniqueActions = dcount(ActionType), TotalEvents = count(), LastActivity = max(Timestamp) by UserId | where UniqueActions >= 5 | order by TotalEvents desc | limit 10",
+            "cluster_url": "https://mycluster.kusto.windows.net",
+            "database": "ApplicationLogs",
+            "output_format": "json",
         },
     }
 
@@ -104,36 +59,16 @@ def example_json_processing() -> Dict[str, Any]:
     }
 
 
-# ============================================================================
-# EXAMPLE 3: Security Analysis Query
-# ============================================================================
-
-
 def example_security_analysis() -> Dict[str, Any]:
     """Execute a security-focused query with threat detection."""
 
     request = {
-        "tool": "kql_execute",
+        "tool": "execute_kql_query",
         "input": {
-            "query": """
-                cluster('security.kusto.windows.net')
-                .database('SecurityEvents')
-                .SigninLogs
-                | where TimeGenerated >= ago(7d)
-                | where ResultType != "0"  // Failed sign-ins only
-                | extend GeoInfo = parse_json(LocationDetails)
-                | extend Country = tostring(GeoInfo.countryOrRegion)
-                | extend City = tostring(GeoInfo.city)
-                | summarize
-                    FailedAttempts = count(),
-                    UniqueIPs = dcount(IPAddress),
-                    Countries = make_set(Country, 10)
-                  by UserPrincipalName
-                | where FailedAttempts >= 10 or UniqueIPs >= 5
-                | order by FailedAttempts desc
-            """,
-            "visualize": True,
-            "use_schema_context": True,
+            "query": "SigninLogs | where TimeGenerated >= ago(7d) | where ResultType != '0' | extend GeoInfo = parse_json(LocationDetails) | extend Country = tostring(GeoInfo.countryOrRegion) | extend City = tostring(GeoInfo.city) | summarize FailedAttempts = count(), UniqueIPs = dcount(IPAddress), Countries = make_set(Country, 10) by UserPrincipalName | where FailedAttempts >= 10 or UniqueIPs >= 5 | order by FailedAttempts desc",
+            "cluster_url": "https://security.kusto.windows.net",
+            "database": "SecurityEvents",
+            "output_format": "table",
         },
     }
 
@@ -144,32 +79,16 @@ def example_security_analysis() -> Dict[str, Any]:
     }
 
 
-# ============================================================================
-# EXAMPLE 5: Performance Optimized Query
-# ============================================================================
-
-
 def example_performance_optimized() -> Dict[str, Any]:
     """Execute a query optimized for performance."""
 
     request = {
-        "tool": "kql_execute",
+        "tool": "execute_kql_query",
         "input": {
-            "query": """
-                cluster('logs.kusto.windows.net')
-                .database('Telemetry')
-                .PerformanceCounters
-                | where TimeGenerated >= ago(1h)
-                | where CounterName in ('% Processor Time', 'Available MBytes')
-                | summarize
-                    AvgValue = avg(CounterValue),
-                    MaxValue = max(CounterValue),
-                    MinValue = min(CounterValue)
-                  by bin(TimeGenerated, 5m), CounterName, Computer
-                | order by TimeGenerated desc
-            """,
-            "visualize": False,  # Disable for faster response
-            "use_schema_context": False,  # Skip context loading for speed
+            "query": "PerformanceCounters | where TimeGenerated >= ago(1h) | where CounterName in ('% Processor Time', 'Available MBytes') | summarize AvgValue = avg(CounterValue), MaxValue = max(CounterValue), MinValue = min(CounterValue) by bin(TimeGenerated, 5m), CounterName, Computer | order by TimeGenerated desc",
+            "cluster_url": "https://logs.kusto.windows.net",
+            "database": "Telemetry",
+            "output_format": "json",
         },
     }
 
@@ -177,47 +96,32 @@ def example_performance_optimized() -> Dict[str, Any]:
         "description": "Performance-optimized query execution",
         "request": request,
         "optimization_techniques": [
-            "Disabled visualization for faster response",
-            "Disabled schema context loading",
-            "Used specific time ranges",
-            "Efficient aggregation with bin()",
+            "Pinned the cluster and database explicitly",
+            "Requested JSON output for cheaper transport",
+            "Used a narrow time range",
+            "Kept aggregation work on the cluster side",
         ],
     }
 
 
-# ============================================================================
-# EXAMPLE 6: Custom Memory Path
-# ============================================================================
-
-
-def example_custom_memory_path() -> Dict[str, Any]:
-    """Use custom memory path for project-specific schema caching."""
+def example_schema_memory() -> Dict[str, Any]:
+    """Discover schema using the current schema_memory tool."""
 
     request = {
-        "tool": "kql_execute",
+        "tool": "schema_memory",
         "input": {
-            "query": """
-                cluster('project-cluster.kusto.windows.net')
-                .database('ProjectData')
-                .UserEvents
-                | take 100
-            """,
-            "cluster_memory_path": "/projects/myproject/kql_memory",
-            "visualize": True,
-            "use_schema_context": True,
+            "operation": "discover",
+            "cluster_url": "https://project-cluster.kusto.windows.net",
+            "database": "ProjectData",
+            "table_name": "UserEvents",
         },
     }
 
     return {
-        "description": "Query with custom memory path for project isolation",
+        "description": "Schema discovery for a target table",
         "request": request,
-        "use_case": "Separate schema caches for different projects",
+        "use_case": "Warm the schema cache before NL2KQL or troubleshooting",
     }
-
-
-# ============================================================================
-# EXAMPLE 7: Error Handling and Debugging
-# ============================================================================
 
 
 def example_error_scenarios() -> Dict[str, Any]:
@@ -225,21 +129,18 @@ def example_error_scenarios() -> Dict[str, Any]:
 
     # Example of query with syntax error
     error_request = {
-        "tool": "kql_execute",
+        "tool": "execute_kql_query",
         "input": {
-            "query": """
-                cluster('help.kusto.windows.net')
-                .database('Samples')
-                .NonExistentTable  // This table doesn't exist
-                | take 10
-            """,
-            "visualize": True,
+            "query": "NonExistentTable | take 10",
+            "cluster_url": "https://help.kusto.windows.net",
+            "database": "Samples",
+            "output_format": "json",
         },
     }
 
     expected_error_response = {
-        "status": "error",
-        "error": "KQL execution: KustoServiceError - Table 'NonExistentTable' not found. Did you mean 'StormEvents' or 'PopulationData'?",
+        "success": False,
+        "error": "KQL execution failed because the table could not be resolved.",
     }
 
     return {
@@ -264,21 +165,21 @@ def usage_patterns():
 
     patterns = {
         "workflow_2_development": [
-            "1. Use visualize=True for data exploration",
-            "2. Use visualize=False for production queries",
-            "3. Enable debug mode for troubleshooting",
+            "1. Run az login before starting the server locally",
+            "2. Use schema_memory(discover/list_tables/get_context) before NL2KQL-heavy sessions",
+            "3. Prefer table or JSON output depending on how your MCP client renders results",
         ],
         "workflow_3_performance": [
-            "1. Run schema discovery once per cluster",
-            "2. Use custom memory paths for project isolation",
-            "3. Disable context loading for high-frequency queries",
+            "1. Keep time windows tight on large telemetry tables",
+            "2. Use summarize/bin() to reduce result volume before transport",
+            "3. Reuse cached schema context instead of rediscovering tables unnecessarily",
         ],
         "best_practices": [
             "Always authenticate with Azure CLI first (az login)",
             "Use specific time ranges to limit query scope",
-            "Enable schema context for development, disable for production",
-            "Use force_refresh when cluster schema changes",
-            "Monitor memory file size for large clusters",
+            "Use schema_memory(refresh_schema) when table metadata changes",
+            "Use schema_memory(get_context) to ground NL2KQL with the right tables",
+            "Keep local Azure CLI auth and Azure-hosted managed identity flows documented separately",
         ],
     }
 
@@ -298,7 +199,7 @@ def main():
         example_json_processing(),
         example_security_analysis(),
         example_performance_optimized(),
-        example_custom_memory_path(),
+        example_schema_memory(),
         example_error_scenarios(),
     ]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mcp-name: io.github.4R9UN/mcp-kql-server
 
 A Model Context Protocol (MCP) server that transforms natural language questions into optimized KQL queries with intelligent schema discovery, AI-powered caching, and seamless Azure Data Explorer integration. Simply ask questions in plain English and get instant, accurate KQL queries with context-aware results.
 
-**Latest Version: v2.1.0** - Now with schema-only NL2KQL and auto-update detection!
+**Latest Version: v2.1.1** - Now with stricter schema-grounded CAG, safer cache scoping, and runtime repair for invalid columns.
 
 <!-- Badges Section -->
 
@@ -35,12 +35,13 @@ Watch a quick demo of the MCP KQL Server in action:
 
 [![MCP KQL Server Demo](https://img.youtube.com/vi/Ca-yuThJ3Vc/0.jpg)](https://www.youtube.com/watch?v=Ca-yuThJ3Vc)
 
-## 🆕 What's New in v2.1.0
+## 🆕 What's New in v2.1.1
 
-- **🎯 Schema-Only NL2KQL**: Natural Language to KQL now uses ONLY data from schema memory - no hardcoded values
-- **🔄 Auto-Update Detection**: Checks PyPI for new versions at startup with optional auto-install
-- **📋 Clean Logs**: Removed Unicode characters for better terminal compatibility
-- **✅ Improved Accuracy**: Better column validation against discovered schema
+- **🎯 Schema-First CAG**: KQL generation now ranks tables and columns from cached schema context before building queries.
+- **🧠 Strict Table Context**: `schema_memory(operation="get_context")` can be scoped to a specific table and returns allowed/recommended columns.
+- **🩹 Schema-Grounded Repair**: Invalid client-generated KQL can be repaired against real schema columns before execution.
+- **💾 Safer Cache Isolation**: Query-result cache is scoped by query, cluster, database, and output namespace.
+- **♻️ No Redundant Reindexing**: Existing cached schemas are reused and no longer overwritten by placeholder discovery paths.
 
 See [RELEASE_NOTES.md](RELEASE_NOTES.md) for full details.
 
@@ -50,12 +51,13 @@ See [RELEASE_NOTES.md](RELEASE_NOTES.md) for full details.
     - **Natural Language to KQL**: Generate KQL queries from natural language descriptions.
     - **Direct KQL Execution**: Execute raw KQL queries.
     - **Multiple Output Formats**: Supports JSON, CSV, and table formats.
-    - **Live Schema Validation**: Ensures query accuracy by using live schema discovery.
+    - **Strict Schema Validation**: Uses discovered schema memory and validation before execution.
+    - **Schema-Grounded Repair**: Repairs invalid columns only when a valid table schema can prove the replacement.
 
 - **`schema_memory`**:
     - **Schema Discovery**: Discover and cache schemas for tables.
     - **Database Exploration**: List all tables within a database.
-    - **AI Context**: Get AI-driven context for tables.
+    - **AI Context**: Get ranked CAG context for tables, with optional table-scoped strict schema output.
     - **Analysis Reports**: Generate reports with visualizations.
     - **Cache Management**: Clear or refresh the schema cache.
     - **Memory Statistics**: Get statistics about the memory usage.
@@ -106,7 +108,7 @@ graph TD
 
 ### Schema Memory Discovery Flow
 
-The `kql_schema_memory` functionality is now seamlessly integrated into the `kql_execute` tool. When you run a query, the server automatically discovers and caches the schema for any tables it hasn't seen before. This on-demand process ensures you always have the context you need without any manual steps.
+The schema memory flow is integrated into query execution, but it now reuses existing cached schema before attempting live discovery. If a table schema is already available in CAG/schema memory, the server will use that cached schema instead of re-indexing it.
 
 ```mermaid
 graph TD
@@ -238,8 +240,8 @@ For any MCP-compatible application:
 python -m mcp_kql_server
 
 # Server provides these tools:
-# - kql_execute: Execute KQL queries with AI context
-# - kql_schema_memory: Discover and cache cluster schemas
+# - execute_kql_query: Execute KQL or generate KQL from natural language
+# - schema_memory: Discover, cache, and inspect cluster schemas
 ```
 ## 🔧 Quick Start
 
@@ -264,8 +266,8 @@ The server starts immediately with:
 
 The server provides two main tools:
 
-> #### `kql_execute` - Execute KQL Queries with AI Context
-> #### `kql_schema_memory` - Discover and Cache Cluster Schemas
+> #### `execute_kql_query` - Execute KQL queries or generate KQL from natural language
+> #### `schema_memory` - Discover, refresh, and inspect cached cluster schemas
 
 
 ## 💡 Usage Examples

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,66 @@
 
 ---
 
+## 🚀 **v2.1.1 - Schema-Grounded CAG & Runtime Accuracy**
+
+> **Strict schema-first generation, safer cache scoping, and repair-before-execute** 
+
+**Release Date**: March 17, 2026
+**Author**: Arjun Trivedi
+**Email**: arjuntrivedi42@yahoo.com
+**Repository**: https://github.com/4R9UN/mcp-kql-server
+
+### 🚀 **What's New in v2.1.1**
+
+This release focuses on correctness and schema fidelity. The server now prefers cached schema/CAG context over re-indexing, generates KQL from ranked schema context, and can repair invalid client-generated KQL only when a real schema proves the replacement.
+
+#### **1. Stricter CAG and Schema Memory Usage**
+- **Schema-First Generation**: NL2KQL generation now uses ranked table and column context from schema memory before building candidate queries.
+- **Strict Table Context**: `schema_memory(operation="get_context")` can now be scoped to a specific table and returns:
+  - allowed columns
+  - recommended columns
+  - preferred time column
+  - compact CAG context
+- **No Redundant Reindexing**: Existing cached schema is reused before live discovery, and empty placeholder discovery paths no longer overwrite rich table schemas.
+
+#### **2. Runtime Query Accuracy**
+- **Schema-Grounded Repair**: When direct KQL contains invalid columns, the server now attempts a schema-backed repair and only executes the repaired query if it fully revalidates.
+- **Improved Join-Aware Generation**: Candidate generation now includes join-aware paths when join hints exist in memory.
+- **Generation Telemetry**: Memory stats now include generation event counts and candidate metrics for tuning.
+
+#### **3. Cache and Runtime Stability**
+- **Scoped Query Cache**: Cached results are now isolated by query text, cluster, database, and cache namespace.
+- **Safe Cache Clearing**: `schema_memory(operation="clear_cache")` now clears real cached state rather than only returning a success message.
+- **Shared Connection Pooling**: Execution paths now use the shared pool instead of a duplicate local client cache path.
+- **Safer Health Checks**: Pool health checks probe only with a registered database and avoid false recycling when no database context exists.
+
+#### **4. Repository Cleanup**
+- **Removed Scratch Docs**: Deleted ad hoc analysis documents that were not part of the shipped project docs.
+- **Version Alignment**: Package metadata, docs, server manifest, and tests are aligned to `2.1.1`.
+
+### 🐛 **Bug Fixes**
+- Fixed repeated schema writes when schema was already available in memory/CAG.
+- Prevented empty placeholder schemas from overwriting real indexed schemas.
+- Fixed direct-query failures caused by invalid generated/client column names such as non-schema time aliases.
+
+### 📦 **Installation & Upgrade**
+
+#### **New Installation**
+```bash
+pip install mcp-kql-server==2.1.1
+```
+
+#### **Upgrade from Previous Versions**
+```bash
+pip install --upgrade mcp-kql-server
+```
+
+### ✅ **Quality Assurance**
+- **Tests**: 76 passed, 1 skipped
+- **Verified**: Generation, execution, runtime cache, health-check, and package-version regression suites passed
+
+---
+
 ## 🚀 **v2.1.0 - NL2KQL Enhancement & Version Management**
 
 > **Schema-Only NL2KQL & Auto-Update Functionality** 🧠

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,7 +53,7 @@ unauthorized data or causing denial of service.
 
 Severity: HIGH
 
-Affected Versions: 2.0.0 - 2.1.0
+Affected Versions: 2.0.0 - 2.1.1
 
 Reproduction Steps:
 1. Call execute_kql_query with query parameter containing malicious KQL
@@ -85,13 +85,14 @@ When using MCP KQL Server, follow these security best practices:
 
 ### Authentication
 
-```python
-# DO: Use Managed Identity in production
-from azure.identity import DefaultAzureCredential
-credential = DefaultAzureCredential()
+```bash
+# DO: Use Azure CLI locally
+az login
 
-# DON'T: Hardcode credentials
-# credential = ClientSecretCredential(tenant_id, client_id, "hardcoded_secret")  # BAD!
+# DO: In Azure-hosted deployments, assign a managed identity to the host
+# and grant that identity the required Azure Data Explorer permissions.
+
+# DON'T: Hardcode credentials or embed secrets in config files
 ```
 
 ### Configuration
@@ -143,7 +144,7 @@ MCP KQL Server includes these security features:
 
 | Feature | Description |
 |---------|-------------|
-| **Azure AD Authentication** | Supports Managed Identity, Service Principal, Device Code |
+| **Azure AD Authentication** | Local usage relies on Azure CLI auth; Azure-hosted deployments can pair the container with managed identity and RBAC |
 | **Query Validation** | Basic KQL syntax validation before execution |
 | **Connection Encryption** | All connections use TLS 1.2+ |
 | **No Credential Storage** | Credentials are never stored on disk |
@@ -187,7 +188,7 @@ MCP KQL Server includes these security features:
 |------|------------|
 | Unauthorized data access | Use Azure RBAC to limit database permissions |
 | Query injection | Validate and sanitize all user inputs |
-| Credential exposure | Use Managed Identity, never hardcode secrets |
+| Credential exposure | Use Azure CLI locally or managed identity in Azure-hosted environments; never hardcode secrets |
 | Data leakage in logs | Set appropriate log levels in production |
 | Cache tampering | Protect local file system permissions |
 
@@ -211,7 +212,7 @@ pip index versions mcp-kql-server
 # Update to latest
 pip install --upgrade mcp-kql-server
 
-# Enable auto-update checks (v2.1.0+)
+# Enable auto-update checks (v2.1.1+)
 # The server automatically checks for updates at startup
 ```
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,58 +1,44 @@
 # Build Stage
 FROM python:3.11-slim as builder
 
-# Prevent Python from writing pyc files and buffering stdout
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements first to leverage Docker cache
-COPY requirements.txt .
+# Build from pyproject.toml so package metadata stays in one place.
+COPY pyproject.toml README.md LICENSE ./
+COPY mcp_kql_server ./mcp_kql_server
 
-# Create wheels for dependencies
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
+RUN python -m pip install --upgrade pip build
+RUN python -m build --wheel --outdir /dist
 
 # Runtime Stage
 FROM python:3.11-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
-# Create a non-root user
 RUN groupadd -r mcpuser && useradd -r -g mcpuser mcpuser
 
-# Install runtime dependencies (curl for healthchecks if needed)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy wheels from builder
-COPY --from=builder /app/wheels /wheels
+COPY --from=builder /dist /dist
+RUN python -m pip install --no-cache-dir /dist/*.whl
 
-# Install dependencies
-RUN pip install --no-cache /wheels/*
+RUN chown -R mcpuser:mcpuser /app /dist
 
-# Copy application code
-COPY . .
-
-# Change ownership to non-root user
-RUN chown -R mcpuser:mcpuser /app
-
-# Switch to non-root user
 USER mcpuser
 
-# Expose port (Container Apps defaults to 80 or 8080, fastmcp uses SSE usually on a configurable port)
-# We'll assume standard MCP port or configure via env var
 ENV PORT=8000
 EXPOSE 8000
 
-# Run the server
-# Assuming the entry point is via the 'mcp-kql-server' command installed by pip (if setup.py exists)
-# OR running the module directly.
-# Based on project structure, we run the module.
-CMD ["python", "-m", "mcp_kql_server.main"]
+CMD ["python", "-m", "mcp_kql_server"]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference - MCP KQL Server
 
-**Version**: 2.2.0
+**Version**: 2.1.1
 **Last Updated**: December 2025
 
 ---
@@ -103,7 +103,7 @@ Manage schema discovery, caching, and AI context generation.
 | `list_tables` | List all tables in a database |
 | `get_context` | Get AI-friendly context for tables |
 | `generate_report` | Generate analysis report with visualizations |
-| `clear_cache` | Clear cached schema data |
+| `clear_cache` | Clear cached query results |
 | `get_stats` | Get memory usage statistics |
 | `refresh_schema` | Force refresh schema for a database |
 
@@ -178,37 +178,31 @@ memory = MemoryManager(db_path="/custom/path/memory.db")
 
 ### 2.2 Methods
 
-#### store_table_schema
+#### store_schema
 
 Store schema information for a table.
 
 ```python
-def store_table_schema(
+def store_schema(
     self,
     cluster: str,
     database: str,
     table: str,
-    columns: Dict[str, str],
-    row_count: Optional[int] = None,
-    source: str = "discovery"
-) -> Dict[str, Any]
+    schema: Dict[str, Any],
+    description: Optional[str] = None
+) -> None
 ```
 
 **Parameters:**
 - `cluster`: Cluster URL
 - `database`: Database name
 - `table`: Table name
-- `columns`: Dictionary of column_name -> data_type
-- `row_count`: Optional row count
-- `source`: Source of schema ("discovery", "manual", "preload")
+- `schema`: Schema dictionary or `{"columns": {...}}` payload
+- `description`: Optional description preserved alongside the schema
 
 **Returns:**
 ```python
-{
-    "stored": True,
-    "table": "StormEvents",
-    "columns_count": 25
-}
+# Stores/updates the cached schema and semantic index in-place.
 ```
 
 ---
@@ -231,9 +225,8 @@ def get_table_schema(
 {
     "table": "StormEvents",
     "columns": {"StartTime": "datetime", ...},
-    "row_count": 59066,
-    "discovered_at": "2024-12-28T10:00:00Z",
-    "ai_context": "..."
+    "last_updated": "2024-12-28T10:00:00Z",
+    "description": "..."
 }
 # Or None if not cached
 ```
@@ -314,25 +307,21 @@ def get_memory_stats(self) -> Dict[str, Any]
 
 ---
 
-#### clear_cache
+#### clear_query_cache
 
-Clear cached data.
+Clear cached query results.
 
 ```python
-def clear_cache(
+def clear_query_cache(
     self,
     cluster: Optional[str] = None,
     database: Optional[str] = None
-) -> Dict[str, int]
+) -> int
 ```
 
 **Returns:**
 ```python
-{
-    "schemas_cleared": 15,
-    "queries_cleared": 234,
-    "embeddings_cleared": 15
-}
+42  # number of cached query results removed
 ```
 
 ---
@@ -490,19 +479,19 @@ summary = monitor.get_metrics_summary()
 
 ## 4. Utility Functions
 
-### 4.1 Query Processing
+### 4.1 Query and identifier helpers
 
 ```python
-from mcp_kql_server.utils import QueryProcessor
+from mcp_kql_server.utils import bracket_if_needed, normalize_cluster_uri, sanitize_filename
 
-processor = QueryProcessor()
+normalize_cluster_uri("help.kusto.windows.net")
+# "https://help.kusto.windows.net"
 
-# Clean query
-cleaned = processor.clean_query("  StormEvents | take 10  ")
+bracket_if_needed("where")
+# "['where']"
 
-# Extract entities
-entities = processor.extract_entities("StormEvents | where State == 'TX'")
-# {"tables": ["StormEvents"], "columns": ["State"], ...}
+sanitize_filename("bad:file/name?.json")
+# "bad_file_name_.json"
 ```
 
 ### 4.2 Error Handling
@@ -598,7 +587,7 @@ from mcp_kql_server.constants import (
     SERVER_NAME,
     __version__,
     DEFAULT_QUERY_TIMEOUT,
-    MAX_ROWS_DEFAULT,
+    LIMITS,
     CONNECTION_CONFIG,
     ERROR_HANDLING_CONFIG
 )
@@ -627,7 +616,7 @@ from mcp_kql_server.constants import (
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 2.2.0 | Dec 2025 | Added performance module, connection pooling |
+| 2.1.1 | Dec 2025 | Improved CAG ranking, cache scoping, and runtime stability |
 | 2.1.0 | Dec 2025 | Schema-only NL2KQL, version checker |
 | 2.0.9 | Nov 2025 | CAG updates, SQLite migration |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # MCP KQL Server Architecture
 
-**Version**: 2.2.0
+**Version**: 2.1.1
 **Author**: Arjun Trivedi
 **Email**: arjuntrivedi42@yahoo.com
 **Last Updated**: December 2025
@@ -15,8 +15,9 @@
 4. [Data Flow Diagrams](#4-data-flow-diagrams)
 5. [Performance Architecture](#5-performance-architecture)
 6. [Memory & Caching Strategy](#6-memory--caching-strategy)
-7. [Security Model](#7-security-model)
-8. [Module Reference](#8-module-reference)
+7. [Multi-Cluster Support](#7-multi-cluster-support)
+8. [Security Model](#8-security-model)
+9. [Module Reference](#9-module-reference)
 
 ---
 
@@ -30,8 +31,11 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
 |---------|-------------|
 | **Natural Language to KQL** | Convert natural language questions to KQL queries |
 | **Schema Memory** | Intelligent caching with SQLite backend |
-| **Connection Pooling** | Efficient client reuse and management |
+| **Connection Pooling** | Efficient client reuse with health checks |
 | **Batch Execution** | Execute multiple queries in parallel |
+| **Configurable TTL Cache** | Query-type-aware caching with automatic cleanup (NEW) |
+| **Multi-Cluster Support** | Track tables across multiple clusters (NEW) |
+| **Health Check Scheduling** | Background connection health monitoring (NEW) |
 | **Auto-Update** | Automatic version checking from PyPI |
 
 ### Design Principles
@@ -60,7 +64,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
                                      │
                                      ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                        MCP KQL Server (v2.2.0)                               │
+│                        MCP KQL Server (v2.1.1)                               │
 │                                                                              │
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
 │  │                         API Layer (mcp_server.py)                       │ │
@@ -75,7 +79,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
 │  │                     Core Processing Layer                                ││
 │  │                                                                          ││
 │  │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐    ││
-│  │  │ QueryProcessor│ │ ErrorHandler │ │SchemaManager │ │ KQLValidator │    ││
+│  │  │Query Helpers │ │ ErrorHandler │ │SchemaManager │ │ KQLValidator │    ││
 │  │  │  (utils.py)  │ │  (utils.py)  │ │  (utils.py)  │ │(kql_validator)│    ││
 │  │  └──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘    ││
 │  │                                                                          ││
@@ -86,7 +90,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
 │  └──────────────────────────────────────────────────────────────────────────┘│
 │                                     │                                        │
 │  ┌──────────────────────────────────┼──────────────────────────────────────┐│
-│  │                     Performance Layer (NEW in v2.2.0)                    ││
+│  │                     Performance Layer (NEW in v2.1.1)                    ││
 │  │                                                                          ││
 │  │  ┌────────────────────┐  ┌────────────────────┐  ┌────────────────────┐ ││
 │  │  │KustoConnectionPool │  │BatchQueryExecutor  │  │  SchemaPreloader   │ ││
@@ -150,7 +154,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
 | `mcp_server.py` | MCP tool registration & routing | `execute_kql_query()`, `schema_memory()` |
 | `execute_kql.py` | KQL execution engine | `kql_execute_tool()`, `_get_kusto_client()` |
 | `memory.py` | Persistent schema storage | `MemoryManager`, `SemanticSearch` |
-| `utils.py` | Utilities & helpers | `QueryProcessor`, `ErrorHandler`, `SchemaManager` |
+| `utils.py` | Utilities & helpers | `normalize_cluster_uri()`, `bracket_if_needed()`, `ErrorHandler`, `SchemaManager` |
 | `kql_auth.py` | Azure authentication | `authenticate_kusto()` |
 | `kql_validator.py` | Query validation | `KQLValidator` |
 | `ai_prompts.py` | NL2KQL prompt templates | `build_nl2kql_prompt()` |
@@ -195,7 +199,7 @@ sequenceDiagram
     participant Server as mcp_server.py
     participant Pool as ConnectionPool
     participant Auth as kql_auth.py
-    participant Processor as QueryProcessor
+    participant Processor as Query Helpers
     participant Memory as MemoryManager
     participant Executor as execute_kql.py
     participant Azure as Azure Data Explorer
@@ -217,9 +221,9 @@ sequenceDiagram
     end
     
     Note over Server: Phase 2: Query Processing
-    Server->>Processor: process_query(query)
-    Processor->>Processor: Clean, validate, extract params
-    Processor->>Server: Return processed query
+    Server->>Processor: normalize identifiers and cluster URI
+    Processor->>Processor: Apply helper-based cleanup
+    Processor->>Server: Return normalized inputs
     
     Note over Server: Phase 3: Schema Context
     Server->>Memory: get_relevant_context(cluster, db, query)
@@ -422,9 +426,48 @@ CREATE TABLE embeddings (
     model_version TEXT,
     created_at TIMESTAMP
 );
+
+-- Query result cache (NEW in v2.1.1)
+CREATE TABLE query_cache (
+    id INTEGER PRIMARY KEY,
+    query_hash TEXT UNIQUE NOT NULL,
+    query_text TEXT NOT NULL,
+    result_json TEXT,
+    query_type TEXT DEFAULT 'default',   -- schema|aggregation|realtime|default
+    ttl_seconds INTEGER DEFAULT 300,
+    cluster TEXT,
+    database TEXT,
+    cached_at TIMESTAMP,
+    expires_at TIMESTAMP
+);
+
+-- Multi-cluster table locations (NEW in v2.1.1)
+CREATE TABLE table_locations (
+    id INTEGER PRIMARY KEY,
+    table_name TEXT NOT NULL,
+    cluster TEXT NOT NULL,
+    database TEXT NOT NULL,
+    last_seen TIMESTAMP,
+    UNIQUE(table_name, cluster, database)
+);
 ```
 
-### 6.2 Caching Hierarchy
+### 6.2 Configurable TTL Cache (NEW)
+
+The query cache now supports query-type-aware TTL settings:
+
+| Query Type | TTL | Use Case |
+|------------|-----|----------|
+| `schema` | 3600s (1 hour) | Schema discovery queries |
+| `aggregation` | 600s (10 min) | Summary/aggregation queries |
+| `realtime` | 60s (1 min) | Recent data queries |
+| `default` | 300s (5 min) | Standard queries |
+
+**Cache Operations:**
+- `cache_stats`: Get detailed cache statistics
+- `cleanup_cache`: Remove expired entries
+
+### 6.3 Caching Hierarchy
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -457,9 +500,56 @@ CREATE TABLE embeddings (
 
 ---
 
-## 7. Security Model
+## 7. Multi-Cluster Support (NEW in v2.1.1)
 
-### 7.1 Authentication Flow
+### 7.1 Table Location Tracking
+
+The server tracks which tables exist in which clusters/databases:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                Multi-Cluster Table Registry                      │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Table: SecurityEvents                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Cluster: prod-east.kusto.windows.net                      │  │
+│  │ Database: SecurityLogs                                     │  │
+│  │ Last Seen: 2024-12-20T10:30:00                            │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Cluster: prod-west.kusto.windows.net                      │  │
+│  │ Database: SecurityLogs                                     │  │
+│  │ Last Seen: 2024-12-20T09:15:00                            │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                  │
+│  API Methods (MemoryManager):                                    │
+│  - register_table_location(table, cluster, database)             │
+│  - get_table_locations(table_name) -> List[Dict]                 │
+│  - is_multi_cluster_table(table_name) -> bool                    │
+│  - get_all_table_locations() -> Dict[str, List[Dict]]            │
+│  - remove_table_location(table, cluster, database)               │
+│                                                                  │
+│  MCP Operations (schema_memory tool):                            │
+│  - list_multi_cluster_tables: List all tracked tables            │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Use Cases
+
+| Scenario | Approach |
+|----------|----------|
+| **Data Replication** | Query from nearest cluster for lower latency |
+| **DR/HA Setup** | Failover to secondary cluster if primary unavailable |
+| **Federated Queries** | Know which clusters have specific tables |
+| **Schema Comparison** | Detect schema differences across clusters |
+
+---
+
+## 8. Security Model
+
+### 8.1 Authentication Flow
 
 ```mermaid
 flowchart TD
@@ -482,7 +572,7 @@ flowchart TD
     style J fill:#1a1f3b,stroke:#26ffa4,stroke-width:2px,color:#ccfff3
 ```
 
-### 7.2 Security Principles
+### 8.2 Security Principles
 
 | Principle | Implementation |
 |-----------|----------------|
@@ -494,7 +584,7 @@ flowchart TD
 
 ---
 
-## 8. Module Reference
+## 9. Module Reference
 
 ### File Structure
 
@@ -505,7 +595,7 @@ mcp_kql_server/
 ├── mcp_server.py        # MCP tool definitions
 ├── execute_kql.py       # Query execution engine
 ├── memory.py            # SQLite-backed memory manager
-├── utils.py             # Utilities (QueryProcessor, ErrorHandler)
+├── utils.py             # Utilities (cluster normalization, schema helpers, ErrorHandler)
 ├── kql_auth.py          # Azure authentication
 ├── kql_validator.py     # KQL syntax validation
 ├── ai_prompts.py        # NL2KQL prompt templates
@@ -546,6 +636,11 @@ from mcp_kql_server import (
 
 ## Conclusion
 
-The MCP KQL Server v2.2.0 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. The addition of connection pooling, batch execution, and performance monitoring in this version significantly improves throughput and resource utilization.
+The MCP KQL Server v2.1.1 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. Key enhancements in this version include:
+
+- **Configurable TTL Cache**: Query-type-aware caching with automatic expiration
+- **Multi-Cluster Support**: Track and query tables across multiple Azure Data Explorer clusters
+- **Health Check Scheduling**: Background connection health monitoring and automatic cleanup
+- **Enhanced Statistics**: Detailed cache and memory statistics via new schema_memory operations
 
 For questions or contributions, please refer to [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide - MCP KQL Server
 
-**Version**: 2.2.0
+**Version**: 2.1.1
 **Last Updated**: December 2025
 
 ---
@@ -25,11 +25,11 @@
 ### Health Check Command
 
 ```bash
-# Check if server is working
-python -m mcp_kql_server --version
+# Check that the package imports and reports the current version
+python -c "from mcp_kql_server import __version__; print(__version__)"
 
-# Test basic connectivity
-python -c "from mcp_kql_server import check_for_updates; print(check_for_updates())"
+# Optional: test version check wiring without starting the server loop
+python -c "from mcp_kql_server.version_checker import check_for_updates; print(check_for_updates())"
 ```
 
 ### Diagnostic Script
@@ -225,10 +225,8 @@ for dep in deps:
    ```
 
 2. **Refresh schema cache:**
-   ```python
-   # Clear and rediscover
-   memory.clear_cache(cluster, database)
-   # Schema will be rediscovered on next query
+   ```text
+   schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
 
 3. **Use schema memory tool:**
@@ -330,16 +328,45 @@ for dep in deps:
 **Solutions:**
 
 1. **Force schema refresh:**
-   ```python
-   from mcp_kql_server.memory import get_memory_manager
-   memory = get_memory_manager()
-   memory.clear_cache(cluster_url, database)
+   ```text
+   schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
 
 2. **Use refresh_schema operation:**
    ```
    schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
+
+---
+
+### Problem: Generated or client-provided KQL uses wrong columns even though schema exists
+
+**Symptoms:**
+- Validation errors for columns such as `Timestamp`, `EventTime`, or generic aliases
+- The table schema is already cached, but the query still uses column names that do not exist in that table
+
+**What v2.1.1 does now:**
+- Reuses cached schema before live re-discovery
+- Avoids overwriting rich cached schema with empty placeholder indexing
+- Repairs direct KQL against the real table schema when a safe replacement can be proven
+
+**Best practice:**
+
+1. **Request strict table-scoped context before generating KQL:**
+   ```
+   schema_memory(
+     operation="get_context",
+     cluster_url="...",
+     database="...",
+     table_name="CreateProcessEvents",
+     natural_language_query="investigate the suspicious process execution"
+   )
+   ```
+
+2. **Use only the returned `allowed_columns` and `recommended_columns`.**
+
+3. **If direct KQL still contains wrong columns, run it through `execute_kql_query`:**
+   The server will attempt a schema-grounded repair and only execute if the repaired query validates fully.
 
 ---
 
@@ -432,7 +459,9 @@ for dep in deps:
 
 1. **Clear old embeddings:**
    ```python
-   memory.clear_cache()
+   from mcp_kql_server.memory import get_memory_manager
+   memory = get_memory_manager()
+   memory.clear_memory()
    ```
 
 2. **Reduce embedding model size:**
@@ -497,7 +526,7 @@ for dep in deps:
 
 3. **Install specific version:**
    ```bash
-   pip install mcp-kql-server==2.2.0
+   pip install mcp-kql-server==2.1.1
    ```
 
 ---

--- a/mcp_kql_server/__init__.py
+++ b/mcp_kql_server/__init__.py
@@ -20,7 +20,7 @@ from .mcp_server import main
 from .version_checker import check_for_updates, get_current_version
 
 # Version information
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __author__ = "Arjun Trivedi"
 __email__ = "arjuntrivedi42@yahoo.com"
 

--- a/mcp_kql_server/constants.py
+++ b/mcp_kql_server/constants.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 
 # Version information - Single source of truth from pyproject.toml
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 VERSION = __version__
 MCP_PROTOCOL_VERSION = "2024-11-05"
 

--- a/mcp_kql_server/execute_kql.py
+++ b/mcp_kql_server/execute_kql.py
@@ -17,12 +17,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import numpy as np
-from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 from azure.kusto.data.exceptions import KustoServiceError
 
 # Constants import
 from .constants import DEFAULT_QUERY_TIMEOUT
 from .memory import get_memory_manager
+from .performance import get_connection_pool
 from .utils import (
     extract_cluster_and_database_from_query,
     extract_tables_from_query,
@@ -37,6 +37,17 @@ logger = logging.getLogger(__name__)
 
 # Import schema validator at module level - now from memory.py
 _schema_validator = None
+
+
+class _PoolCacheShim(dict):
+    """Compatibility shim for tests/helpers that expect a clearable client cache."""
+
+    def clear(self):
+        get_connection_pool().close_all()
+        super().clear()
+
+
+_client_cache = _PoolCacheShim()
 
 def get_schema_validator():
     """Lazy load schema validator to avoid circular imports."""
@@ -98,19 +109,11 @@ def validate_query(query: str) -> Tuple[str, str]:
 
 
 # Use centralized normalize_cluster_uri from utils.py
-# Client cache for pooling
-_client_cache = {}
-
-def _get_kusto_client(cluster_url: str) -> KustoClient:
-    """Create and authenticate a Kusto client with pooling."""
+def _get_kusto_client(cluster_url: str) -> Any:
+    """Get a pooled Kusto client."""
     normalized_url = normalize_cluster_uri(cluster_url)
-
-    if normalized_url not in _client_cache:
-        logger.info("Creating new Kusto client for %s", normalized_url)
-        kcsb = KustoConnectionStringBuilder.with_az_cli_authentication(normalized_url)
-        _client_cache[normalized_url] = KustoClient(kcsb)
-
-    return _client_cache[normalized_url]
+    pool = get_connection_pool()
+    return pool.get_client(normalized_url)
 
 def _parse_kusto_response(response) -> pd.DataFrame:
     """Parse a Kusto response into a pandas DataFrame."""
@@ -149,6 +152,7 @@ def _execute_kusto_query_sync(kql_query: str, cluster: str, database: str, _time
     cluster_url = normalize_cluster_uri(cluster)
     logger.info("Executing KQL on %s/%s: %s...", cluster_url, database, kql_query[:150])
 
+    get_connection_pool().register_health_check_database(cluster_url, database)
     client = _get_kusto_client(cluster_url)
     start_time = time.time()
     try:
@@ -470,7 +474,12 @@ async def execute_kql_query(
         if use_cache:
             try:
                 memory = get_memory_manager()
-                cached_json = memory.get_cached_result(query)
+                cached_json = memory.get_cached_result(
+                    query,
+                    cluster=cluster,
+                    database=database,
+                    cache_namespace="legacy_execute",
+                )
                 if cached_json:
                     logger.info("Returning cached result for query")
                     return json.loads(cached_json)
@@ -555,7 +564,14 @@ async def execute_kql_query(
                 try:
 
                     memory = get_memory_manager()
-                    memory.cache_query_result(query, json.dumps(records), len(records))
+                    memory.cache_query_result(
+                        query,
+                        json.dumps(records),
+                        len(records),
+                        cluster=cluster,
+                        database=database,
+                        cache_namespace="legacy_execute",
+                    )
                 except Exception as e:
                     logger.debug("Failed to cache result: %s", e)
 

--- a/mcp_kql_server/kql_auth.py
+++ b/mcp_kql_server/kql_auth.py
@@ -44,19 +44,25 @@ def kql_auth():
         env = os.environ.copy()
         subprocess.run(
             [az_command, "config", "set", "core.login_experience_v2=off"],
-            env=env, capture_output=True, text=True, check=True
+            env=env, capture_output=True, text=True, check=True, timeout=60
         )
         subprocess.run(
             [az_command, "account", "get-access-token"],
-            capture_output=True, text=True, check=True
+            env=env, capture_output=True, text=True, check=True, timeout=60
         )
         logger.info("User is authenticated with Azure CLI.")
         return {"authenticated": True, "message": "User is authenticated."}
+    except subprocess.TimeoutExpired:
+        logger.error("Authentication check timed out.")
+        return {"authenticated": False, "message": "Authentication check timed out."}
     except subprocess.CalledProcessError as e:
         logger.warning("User is not authenticated: %s", e.stderr)
         return {"authenticated": False, "message": "User is not authenticated."}
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error("Authentication check failed: %s", str(e))
+        return {"authenticated": False, "message": str(e)}
+    except Exception as e:  # Required for test compatibility (test_kql_auth_exception)
+        logger.error("Unexpected error during authentication: %s", str(e))
         return {"authenticated": False, "message": str(e)}
 
 @retry(stop=stop_after_attempt(2), wait=wait_exponential(multiplier=1, min=2, max=10))
@@ -75,7 +81,7 @@ def trigger_az_cli_auth():
     try:
         subprocess.run(
             [az_command, "config", "set", "core.login_experience_v2=off"],
-            env=env, capture_output=True, text=True, check=True
+            env=env, capture_output=True, text=True, check=True, timeout=60
         )
         auth_result = subprocess.run(
             [az_command, "login", "--use-device-code"],
@@ -89,7 +95,7 @@ def trigger_az_cli_auth():
     except subprocess.TimeoutExpired:
         logger.error("Authentication timed out.")
         return {"authenticated": False, "message": "Authentication timed out. Please try again."}
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error("Authentication attempt failed: %s", str(e))
         return {"authenticated": False, "message": str(e)}
 

--- a/mcp_kql_server/kql_validator.py
+++ b/mcp_kql_server/kql_validator.py
@@ -10,6 +10,7 @@ Email: arjuntrivedi42@yahoo.com
 
 import re
 import logging
+import difflib
 from typing import Dict, List, Any
 
 from .constants import KQL_RESERVED_WORDS
@@ -121,30 +122,107 @@ class KQLValidator:
             }
 
     def _extract_tables(self, query: str) -> List[str]:
-        """Extract table names from KQL query."""
+        """
+        Extract table names from KQL query.
+        
+        Handles multiple query patterns including:
+        - Simple table references: TableName | where ...
+        - Cross-cluster: cluster('...').database('...').TableName
+        - Let blocks: let x = ...; TableName | where ...
+        - Join/union operations
+        - Bracketed table names
+        """
         tables = set()
 
-        # Pattern 1: Table at start or after pipe
+        # Pattern 1: Cross-cluster pattern (HIGHEST PRIORITY)
+        # Matches: cluster('...').database('...').TableName
+        pattern_cross_cluster = r'\.database\s*\(\s*[\'"][^\'"]+[\'"]\s*\)\s*\.([A-Za-z_][\w]*)'
+        
+        # Pattern 2: Table after semicolon (for let statements)
+        # Matches: ; TableName | ... or ;\nTableName
+        pattern_after_let = r';\s*\n?\s*([A-Za-z_][\w]*)\s*(?:\||$)'
+        
+        # Pattern 3: Table at start of line or after pipe (with MULTILINE support)
         # Matches: TableName | ..., | TableName, etc.
-        pattern1 = r'(?:^|\|\s*)([A-Za-z_][\w]*)\s*(?:\||$)'
+        pattern_line_start = r'(?:^|\|\s*)([A-Za-z_][\w]*)\s*(?:\||$)'
 
-        # Pattern 2: Join/union operations
+        # Pattern 4: Join/union operations
         # Matches: join Table, union Table, lookup Table
-        pattern2 = r'(?:join|union|lookup)\s+(?:kind\s*=\s*\w+\s+)?([A-Za-z_][\w]*)'
+        pattern_join = r'(?:join|union|lookup)\s+(?:kind\s*=\s*\w+\s+)?([A-Za-z_][\w]*)'
 
-        # Pattern 3: Bracketed table names
+        # Pattern 5: Bracketed table names
         # Matches: ['TableName'], ["TableName"]
-        pattern3 = r'\[[\'"]([\ w\s-]+)[\'"]\]'
+        pattern_bracket = r'\[[\'"]([A-Za-z_][\w\s-]+)[\'"]\]'
+        
+        # Pattern 6: Table in datatable or materialize
+        # Matches: datatable (...) [...] | ..., materialize(TableName)
+        pattern_materialize = r'materialize\s*\(\s*([A-Za-z_][\w]*)\s*\)'
 
-        for pattern in [pattern1, pattern2, pattern3]:
-            matches = re.finditer(pattern, query, re.IGNORECASE)
-            for match in matches:
-                table_name = match.group(1).strip()
-                # Filter out KQL keywords
-                if not self._is_kql_keyword(table_name):
-                    tables.add(table_name)
+        # Apply patterns with appropriate flags
+        patterns_with_flags = [
+            (pattern_cross_cluster, re.IGNORECASE),
+            (pattern_after_let, re.IGNORECASE | re.MULTILINE),
+            (pattern_line_start, re.IGNORECASE | re.MULTILINE),
+            (pattern_join, re.IGNORECASE),
+            (pattern_bracket, re.IGNORECASE),
+            (pattern_materialize, re.IGNORECASE),
+        ]
 
+        for pattern, flags in patterns_with_flags:
+            try:
+                matches = re.finditer(pattern, query, flags)
+                for match in matches:
+                    table_name = match.group(1).strip()
+                    # Filter out KQL keywords and common false positives
+                    if table_name and not self._is_kql_keyword(table_name):
+                        # Additional filter: skip variable-like names in let statements
+                        if not self._is_let_variable(query, table_name):
+                            tables.add(table_name)
+            except re.error as e:
+                logger.warning("Regex error in table extraction: %s", e)
+
+        # If no tables found, try fallback extraction
+        if not tables:
+            tables = self._fallback_table_extraction(query)
+        
+        logger.debug("Extracted tables from query: %s", list(tables))
         return list(tables)
+    
+    def _is_let_variable(self, query: str, name: str) -> bool:
+        """
+        Check if a name is defined as a let variable in the query.
+        This prevents extracting let variable names as table names.
+        """
+        # Pattern: let VariableName = ...
+        let_pattern = rf'\blet\s+{re.escape(name)}\s*='
+        return bool(re.search(let_pattern, query, re.IGNORECASE))
+    
+    def _fallback_table_extraction(self, query: str) -> set:
+        """
+        Fallback table extraction for complex queries.
+        Uses heuristics when standard patterns fail.
+        """
+        tables = set()
+        
+        # Remove comments and string literals to avoid false positives
+        cleaned = re.sub(r'//.*$', '', query, flags=re.MULTILINE)  # Remove line comments
+        cleaned = re.sub(r'/\*.*?\*/', '', cleaned, flags=re.DOTALL)  # Remove block comments
+        cleaned = re.sub(r'"[^"]*"', '""', cleaned)  # Replace string literals
+        cleaned = re.sub(r"'[^']*'", "''", cleaned)  # Replace string literals
+        
+        # Split by common KQL delimiters and look for table-like identifiers
+        # Tables typically appear: after database().TABLE or at statement boundaries
+        
+        # Look for identifiers that look like table names (PascalCase or with Events/Log suffix)
+        table_like_pattern = r'\b([A-Z][a-zA-Z0-9]*(?:Events?|Log|Table|Data|Records?)?)\b'
+        for match in re.finditer(table_like_pattern, cleaned):
+            candidate = match.group(1)
+            if (len(candidate) > 3 and 
+                not self._is_kql_keyword(candidate) and
+                not self._is_let_variable(query, candidate)):
+                tables.add(candidate)
+        
+        return tables
 
     def _is_kql_keyword(self, word: str) -> bool:
         """Check if word is a KQL keyword using centralized reserved words."""
@@ -206,14 +284,26 @@ class KQLValidator:
 
             # Extract column references for this table
             column_refs = self._extract_column_references(query, table)
+            column_names = list(columns.keys())
 
             # Validate each column reference
             for col_ref in column_refs:
                 if col_ref not in columns:
-                    errors.append(
-                        f"Column '{col_ref}' not found in table '{table}'. "
-                        f"Available columns: {', '.join(sorted(columns.keys()))}"
-                    )
+                    # Use fuzzy matching to suggest similar column names
+                    suggestions = self._find_similar_columns(col_ref, column_names)
+                    if suggestions:
+                        errors.append(
+                            f"Column '{col_ref}' not found in table '{table}'. "
+                            f"Did you mean: {', '.join(suggestions)}?"
+                        )
+                    else:
+                        # Show first 10 available columns as reference
+                        sample_cols = sorted(column_names)[:10]
+                        errors.append(
+                            f"Column '{col_ref}' not found in table '{table}'. "
+                            f"Sample columns: {', '.join(sample_cols)}"
+                            + (f"... ({len(column_names)} total)" if len(column_names) > 10 else "")
+                        )
                 else:
                     validated_count += 1
 
@@ -223,11 +313,43 @@ class KQLValidator:
             logger.warning("Table validation failed for %s: %s", table, e)
             return errors, warnings, 0
 
+    def _find_similar_columns(
+        self, 
+        invalid_col: str, 
+        valid_columns: List[str],
+        n: int = 3,
+        cutoff: float = 0.5
+    ) -> List[str]:
+        """
+        Find similar column names using fuzzy matching.
+        
+        Args:
+            invalid_col: The invalid column name from the query
+            valid_columns: List of valid column names from schema
+            n: Maximum number of suggestions to return
+            cutoff: Minimum similarity ratio (0-1) for a match
+            
+        Returns:
+            List of similar column names, sorted by similarity
+        """
+        # Use difflib for fuzzy matching
+        matches = difflib.get_close_matches(
+            invalid_col.lower(),
+            [c.lower() for c in valid_columns],
+            n=n,
+            cutoff=cutoff
+        )
+        
+        # Map back to original case
+        lower_to_original = {c.lower(): c for c in valid_columns}
+        return [lower_to_original.get(m, m) for m in matches]
+
     def _extract_column_references(self, query: str, _table: str) -> List[str]:
         """
         Extract column references from query that need validation.
         
         Only extracts columns being READ from tables, NOT aliases being CREATED.
+        Covers: WHERE, PROJECT, EXTEND, SUMMARIZE, SORT/ORDER BY, JOIN, TOP
         """
         columns = set()
         
@@ -262,6 +384,65 @@ class KQLValidator:
                 if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
                     columns.add(col_name)
         
+        # ============================================================
+        # NEW: Pattern for columns in PROJECT clause (critical fix)
+        # Handles: | project Col1, Col2, Alias = Col3
+        # ============================================================
+        project_pattern = r'\|\s*project\s+([^|]+?)(?=\||$)'
+        for match in re.finditer(project_pattern, query, re.IGNORECASE | re.DOTALL):
+            project_clause = match.group(1).strip()
+            # Parse each item in the project list
+            for col_item in self._split_by_comma_respecting_parens(project_clause):
+                col_item = col_item.strip()
+                if not col_item:
+                    continue
+                
+                if '=' in col_item:
+                    # Format: Alias = SourceColumn or Alias = expression
+                    # Extract columns from the right side (source)
+                    _, right_side = col_item.split('=', 1)
+                    source_cols = self._extract_columns_from_expression(
+                        right_side, created_aliases, aggregation_functions
+                    )
+                    columns.update(source_cols)
+                else:
+                    # Simple column reference (no alias)
+                    col_name = col_item.strip()
+                    # Check it's a valid identifier
+                    if re.match(r'^[A-Za-z_][\w]*$', col_name):
+                        if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
+                            columns.add(col_name)
+        
+        # ============================================================
+        # NEW: Pattern for project-away and project-keep
+        # All columns listed are being READ from the table
+        # ============================================================
+        project_away_pattern = r'\|\s*project-(?:away|keep)\s+([^|]+?)(?=\||$)'
+        for match in re.finditer(project_away_pattern, query, re.IGNORECASE | re.DOTALL):
+            cols_list = match.group(1).strip()
+            for col_item in self._split_by_comma_respecting_parens(cols_list):
+                col_name = col_item.strip()
+                if re.match(r'^[A-Za-z_][\w]*$', col_name):
+                    if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
+                        columns.add(col_name)
+        
+        # ============================================================
+        # NEW: Pattern for source columns in EXTEND expressions
+        # Handles: | extend NewCol = SourceCol + 1
+        # ============================================================
+        extend_pattern = r'\|\s*extend\s+([^|]+?)(?=\||$)'
+        for match in re.finditer(extend_pattern, query, re.IGNORECASE | re.DOTALL):
+            extend_clause = match.group(1).strip()
+            # Parse each assignment in the extend
+            for assignment in self._split_by_comma_respecting_parens(extend_clause):
+                if '=' in assignment:
+                    # Extract source columns from the expression (right side)
+                    _, expr = assignment.split('=', 1)
+                    source_cols = self._extract_columns_from_expression(
+                        expr, created_aliases, aggregation_functions
+                    )
+                    columns.update(source_cols)
+        
         # Pattern for columns in summarize BY clause (reading from table)
         summarize_by_pattern = r'\|\s*summarize\s+.+?\s+by\s+([^|]+?)(?=\||$)'
         for match in re.finditer(summarize_by_pattern, query, re.IGNORECASE | re.DOTALL):
@@ -294,8 +475,35 @@ class KQLValidator:
             if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
                 columns.add(col_name)
         
-        # Pattern for columns in order by / sort by (only validate if before summarize or references table columns)
-        # Skip these as they often reference summarize output columns
+        # ============================================================
+        # NEW: Pattern for SORT BY / ORDER BY columns (before summarize)
+        # Only validate columns that appear before any summarize clause
+        # ============================================================
+        # Check if query has summarize - if so, sort/order columns after may be aliases
+        has_summarize = bool(re.search(r'\|\s*summarize\s+', query, re.IGNORECASE))
+        
+        if not has_summarize:
+            # Safe to validate sort/order by columns
+            sort_pattern = r'\|\s*(?:sort|order)\s+by\s+([^|]+?)(?=\||$)'
+            for match in re.finditer(sort_pattern, query, re.IGNORECASE | re.DOTALL):
+                sort_clause = match.group(1).strip()
+                for part in sort_clause.split(','):
+                    # Remove asc/desc modifiers
+                    part = re.sub(r'\b(asc|desc|nulls\s+first|nulls\s+last)\b', '', part, flags=re.IGNORECASE)
+                    col_name = part.strip()
+                    if re.match(r'^[A-Za-z_][\w]*$', col_name):
+                        if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
+                            columns.add(col_name)
+        
+        # ============================================================
+        # NEW: Pattern for TOP N BY column
+        # Handles: | top 10 by ColumnName
+        # ============================================================
+        top_pattern = r'\|\s*top\s+\d+\s+by\s+([A-Za-z_][\w]*)'
+        for match in re.finditer(top_pattern, query, re.IGNORECASE):
+            col_name = match.group(1).strip()
+            if not self._is_kql_keyword(col_name) and col_name not in created_aliases:
+                columns.add(col_name)
         
         # Pattern for columns in join conditions
         join_pattern = r'\|\s*join\s+.+?\s+on\s+([^|]+?)(?=\||$)'
@@ -310,6 +518,80 @@ class KQLValidator:
                         columns.add(col_name)
 
         return list(columns)
+    
+    def _split_by_comma_respecting_parens(self, text: str) -> List[str]:
+        """
+        Split text by commas, but respect parentheses nesting.
+        E.g., 'a, func(b, c), d' -> ['a', 'func(b, c)', 'd']
+        """
+        result = []
+        current = []
+        depth = 0
+        
+        for char in text:
+            if char == '(':
+                depth += 1
+                current.append(char)
+            elif char == ')':
+                depth -= 1
+                current.append(char)
+            elif char == ',' and depth == 0:
+                result.append(''.join(current))
+                current = []
+            else:
+                current.append(char)
+        
+        if current:
+            result.append(''.join(current))
+        
+        return result
+    
+    def _extract_columns_from_expression(
+        self, 
+        expr: str, 
+        created_aliases: set,
+        aggregation_functions: set
+    ) -> set:
+        """
+        Extract column references from a KQL expression.
+        Filters out KQL functions, keywords, and created aliases.
+        """
+        columns = set()
+        
+        # Remove string literals to avoid false positives
+        expr = re.sub(r'"[^"]*"', '""', expr)
+        expr = re.sub(r"'[^']*'", "''", expr)
+        
+        # KQL scalar functions to exclude
+        kql_functions = {
+            'toupper', 'tolower', 'strlen', 'substring', 'strcat', 'split',
+            'replace', 'trim', 'ltrim', 'rtrim', 'extract', 'parse_json',
+            'toint', 'tolong', 'todouble', 'tostring', 'todatetime', 'totimespan',
+            'datetime', 'ago', 'now', 'bin', 'floor', 'ceiling', 'round',
+            'abs', 'sign', 'sqrt', 'pow', 'exp', 'log', 'log10',
+            'isnotempty', 'isempty', 'isnull', 'isnotnull', 'coalesce',
+            'iff', 'iif', 'case', 'pack', 'pack_all', 'dynamic',
+            'array_length', 'array_concat', 'array_slice', 'mv_expand',
+            'parse_path', 'parse_url', 'parse_urlquery', 'base64_encode_tostring',
+            'base64_decode_tostring', 'hash', 'hash_sha256', 'format_datetime',
+            'make_datetime', 'datetime_diff', 'datetime_add', 'startofday',
+            'startofweek', 'startofmonth', 'startofyear', 'endofday',
+            'gettype', 'typeof', 'toreal', 'tobool', 'toguid',
+        }
+        all_functions = kql_functions | aggregation_functions
+        
+        # Find all identifiers in the expression
+        identifiers = re.findall(r'\b([A-Za-z_][\w]*)\b', expr)
+        
+        for ident in identifiers:
+            ident_lower = ident.lower()
+            # Skip if it's a KQL function, keyword, or created alias
+            if (ident_lower not in {f.lower() for f in all_functions} and
+                not self._is_kql_keyword(ident) and
+                ident not in created_aliases):
+                columns.add(ident)
+        
+        return columns
     
     def _extract_created_aliases(self, query: str) -> set:
         """

--- a/mcp_kql_server/mcp_server.py
+++ b/mcp_kql_server/mcp_server.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import difflib
 from datetime import datetime
 from typing import Dict, Optional, List, Any
 
@@ -45,6 +46,498 @@ kql_validator = KQLValidator(memory_manager, schema_manager)
 
 # Global kusto manager - will be set at startup
 kusto_manager_global = None
+
+GENERATION_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "by", "find", "for", "from", "get",
+    "how", "in", "last", "latest", "list", "me", "of", "on", "recent", "show",
+    "that", "the", "to", "top", "with"
+}
+
+
+def _tokenize_generation_text(text: str) -> List[str]:
+    """Tokenize NL queries and identifiers for ranking/generation heuristics."""
+    normalized = re.sub(r'([a-z0-9])([A-Z])', r'\1 \2', text or "")
+    tokens = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', normalized.lower())
+    return [token for token in tokens if len(token) > 1 and token not in GENERATION_STOPWORDS]
+
+
+def _tokenize_identifier(name: str) -> List[str]:
+    """Split an identifier into comparable lowercase tokens."""
+    return _tokenize_generation_text(name.replace("_", " "))
+
+
+def _extract_requested_limit(nl_query: str, default: int = 10) -> int:
+    """Extract requested result size from natural language."""
+    match = re.search(r'\b(?:top|first|last)\s+(\d{1,4})\b', nl_query, re.IGNORECASE)
+    if match:
+        return max(1, min(int(match.group(1)), 500))
+    return default
+
+
+def _extract_column_suggestions(error_message: str) -> List[str]:
+    """Extract suggested replacement columns from a validator error string."""
+    if "Did you mean:" not in error_message:
+        return []
+    suggestion_text = error_message.split("Did you mean:", 1)[1].strip().rstrip("?")
+    return [part.strip() for part in suggestion_text.split(",") if part.strip()]
+
+
+def _choose_preferred_time_column(schema_columns: Dict[str, Any]) -> Optional[str]:
+    """Pick the best canonical time column from a schema."""
+    preferred_names = [
+        "TimeGenerated", "Timestamp", "ReportTime", "EventTime",
+        "FirstSeenDateTime", "LastSeenDateTime", "CreatedOn",
+    ]
+    for name in preferred_names:
+        if name in schema_columns:
+            return name
+
+    for column_name, column_def in schema_columns.items():
+        data_type = column_def.get("data_type") if isinstance(column_def, dict) else column_def
+        if str(data_type).lower() == "datetime":
+            return column_name
+    return None
+
+
+def _choose_schema_replacement(
+    invalid_column: str,
+    schema_columns: Dict[str, Any],
+    suggested_columns: Optional[List[str]] = None,
+) -> Optional[str]:
+    """Choose the best schema-backed replacement for an invalid column."""
+    if suggested_columns:
+        for suggestion in suggested_columns:
+            if suggestion in schema_columns:
+                return suggestion
+
+    time_column = _choose_preferred_time_column(schema_columns)
+    invalid_tokens = set(_tokenize_identifier(invalid_column))
+    invalid_lower = invalid_column.lower()
+
+    if {"time", "date", "timestamp"} & invalid_tokens and time_column:
+        return time_column
+
+    ranked_candidates = []
+    for column_name in schema_columns:
+        column_tokens = set(_tokenize_identifier(column_name))
+        score = 0.0
+        score += len(invalid_tokens & column_tokens) * 2.5
+        score += 1.5 * difflib.SequenceMatcher(None, invalid_lower, column_name.lower()).ratio()
+
+        if "command" in invalid_lower and "command" in column_name.lower():
+            score += 2.0
+        if "account" in invalid_lower and "account" in column_name.lower():
+            score += 2.0
+        if "parent" in invalid_lower and "parent" in column_name.lower():
+            score += 2.0
+        if "file" in invalid_lower and "file" in column_name.lower():
+            score += 2.0
+        if "path" in invalid_lower and "path" in column_name.lower():
+            score += 2.0
+
+        ranked_candidates.append((score, column_name))
+
+    ranked_candidates.sort(reverse=True)
+    if ranked_candidates and ranked_candidates[0][0] >= 2.4:
+        return ranked_candidates[0][1]
+    return None
+
+
+async def _repair_query_with_schema_context(
+    query: str,
+    cluster_url: str,
+    database: str,
+    validation_result: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """
+    Attempt a schema-grounded repair for invalid user/client-generated KQL.
+
+    Only returns a repaired query if the rewritten query fully revalidates.
+    """
+    tables = validation_result.get("tables_used", [])
+    if len(tables) != 1:
+        return None
+
+    table_name = tables[0]
+    schema_info = await schema_manager.get_table_schema(cluster_url, database, table_name)
+    if not schema_info or not schema_info.get("columns"):
+        return None
+
+    schema_columns = schema_info["columns"]
+    repaired_query = query
+    replacements: Dict[str, str] = {}
+
+    for error in validation_result.get("errors", []):
+        match = re.search(r"Column '([^']+)' not found", error)
+        if not match:
+            continue
+
+        invalid_column = match.group(1)
+        if invalid_column in replacements:
+            continue
+
+        replacement = _choose_schema_replacement(
+            invalid_column,
+            schema_columns,
+            suggested_columns=_extract_column_suggestions(error),
+        )
+        if replacement and replacement != invalid_column:
+            repaired_query = re.sub(
+                rf"\b{re.escape(invalid_column)}\b",
+                replacement,
+                repaired_query,
+            )
+            replacements[invalid_column] = replacement
+
+    if not replacements:
+        return None
+
+    repaired_validation = await kql_validator.validate_query(
+        query=repaired_query,
+        cluster=cluster_url,
+        database=database,
+        auto_discover=False,
+    )
+    if not repaired_validation.get("valid"):
+        return None
+
+    return {
+        "query": repaired_query,
+        "replacements": replacements,
+        "schema_columns": list(schema_columns.keys())[:25],
+        "preferred_time_column": _choose_preferred_time_column(schema_columns),
+        "table_name": table_name,
+    }
+
+
+def _extract_time_window(nl_query: str) -> Optional[str]:
+    """Convert common NL time windows into KQL ago() units."""
+    lower_query = nl_query.lower()
+    match = re.search(
+        r'\b(?:last|past)\s+(\d+)\s+(minute|minutes|min|hour|hours|day|days|week|weeks|month|months)\b',
+        lower_query,
+    )
+    if match:
+        value = int(match.group(1))
+        unit = match.group(2)
+        if unit.startswith("min"):
+            return f"{value}m"
+        if unit.startswith("hour"):
+            return f"{value}h"
+        if unit.startswith("day"):
+            return f"{value}d"
+        if unit.startswith("week"):
+            return f"{value * 7}d"
+        if unit.startswith("month"):
+            return f"{value * 30}d"
+
+    if "today" in lower_query:
+        return "1d"
+    if "yesterday" in lower_query:
+        return "2d"
+    if any(marker in lower_query for marker in ("recent", "latest", "newest")):
+        return "24h"
+    return None
+
+
+def _detect_generation_intent(nl_query: str) -> Dict[str, Any]:
+    """Infer lightweight generation intent from an NL query."""
+    lower_query = nl_query.lower()
+    tokens = _tokenize_generation_text(nl_query)
+    keywords = re.findall(r"""['"]([^'"]+)['"]""", nl_query)
+    needs_trend = any(
+        marker in lower_query for marker in ("trend", "over time", "timeline", "hourly", "daily")
+    )
+    needs_count = any(
+        marker in lower_query for marker in ("count", "how many", "total", "number of")
+    )
+    needs_top = bool(re.search(r'\btop\s+\d+\b', lower_query)) or "most" in lower_query
+    needs_latest = any(marker in lower_query for marker in ("latest", "recent", "newest", "last records"))
+    wants_distinct = any(marker in lower_query for marker in ("distinct", "unique"))
+    needs_join = any(
+        marker in lower_query for marker in ("join", "correlate", "combine", "enrich", "across")
+    )
+
+    return {
+        "tokens": tokens,
+        "keywords": keywords[:2],
+        "limit": _extract_requested_limit(nl_query, default=10),
+        "time_window": _extract_time_window(nl_query),
+        "needs_trend": needs_trend,
+        "needs_count": needs_count,
+        "needs_top": needs_top,
+        "needs_latest": needs_latest or not (needs_trend or needs_count or needs_top),
+        "wants_distinct": wants_distinct,
+        "needs_join": needs_join,
+    }
+
+
+def _pick_generation_columns(table_info: Dict[str, Any], intent: Dict[str, Any]) -> Dict[str, Any]:
+    """Choose the best columns for the requested NL intent."""
+    fingerprinted = table_info.get("fingerprinted_columns", [])
+    if not fingerprinted:
+        fingerprinted = [
+            {"name": name, "data_type": "string", "score": 0.0}
+            for name in list((table_info.get("columns") or {}).keys())[:8]
+        ]
+
+    time_column = next(
+        (
+            column["name"]
+            for column in fingerprinted
+            if column.get("data_type") == "datetime"
+            or any(token in column["name"].lower() for token in ("time", "date", "timestamp"))
+        ),
+        None,
+    )
+    group_column = next(
+        (
+            column["name"]
+            for column in fingerprinted
+            if column["name"] != time_column and column.get("data_type") in {"string", "guid"}
+        ),
+        None,
+    )
+    filter_column = next(
+        (
+            column["name"]
+            for column in fingerprinted
+            if column["name"] not in {time_column, group_column}
+            and column.get("data_type") in {"string", "guid"}
+        ),
+        group_column,
+    )
+
+    output_columns = []
+    if time_column:
+        output_columns.append(time_column)
+    for column in fingerprinted:
+        if column["name"] not in output_columns:
+            output_columns.append(column["name"])
+        if len(output_columns) >= min(max(intent["limit"], 6), 8):
+            break
+
+    return {
+        "time_column": time_column,
+        "group_column": group_column,
+        "filter_column": filter_column,
+        "output_columns": output_columns[:8],
+    }
+
+
+def _build_time_filter(intent: Dict[str, Any], time_column: Optional[str]) -> str:
+    """Build a time filter clause when the query implies recency."""
+    if not time_column or not intent.get("time_window"):
+        return ""
+    return f" | where {bracket_if_needed(time_column)} > ago({intent['time_window']})"
+
+
+def _trend_bucket(time_window: Optional[str]) -> str:
+    """Choose a sensible bin size for trend queries."""
+    if not time_window:
+        return "1h"
+    if time_window.endswith("m"):
+        return "5m"
+    if time_window.endswith("h"):
+        hours = int(time_window[:-1])
+        return "15m" if hours <= 6 else "1h"
+    days = int(time_window[:-1]) if time_window.endswith("d") else 1
+    return "1h" if days <= 2 else "1d"
+
+
+def _build_candidate_queries(
+    table_info: Dict[str, Any],
+    intent: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Build deterministic candidate KQL queries for reranking."""
+    table_name = bracket_if_needed(table_info["table"])
+    column_plan = _pick_generation_columns(table_info, intent)
+    time_column = column_plan["time_column"]
+    group_column = column_plan["group_column"]
+    filter_column = column_plan["filter_column"]
+    output_columns = column_plan["output_columns"] or [column["name"] for column in table_info.get("fingerprinted_columns", [])[:6]]
+    project_clause = ", ".join(bracket_if_needed(column) for column in output_columns)
+    time_filter = _build_time_filter(intent, time_column)
+    filter_keyword = intent["keywords"][0].replace("'", "''") if intent["keywords"] else None
+    keyword_filter = ""
+    if filter_keyword and filter_column:
+        keyword_filter = f" | where {bracket_if_needed(filter_column)} has '{filter_keyword}'"
+
+    candidates: List[Dict[str, Any]] = []
+
+    if intent["needs_trend"] and time_column:
+        bucket = _trend_bucket(intent["time_window"])
+        candidates.append({
+            "template": "trend",
+            "query": (
+                f"{table_name}{time_filter}{keyword_filter}"
+                f" | summarize count() by bin({bracket_if_needed(time_column)}, {bucket})"
+                f" | order by {bracket_if_needed(time_column)} asc"
+            ),
+            "columns_used": [column for column in [time_column, filter_column] if column],
+        })
+
+    if (intent["needs_count"] or intent["needs_top"] or intent["wants_distinct"]) and group_column:
+        if intent["wants_distinct"]:
+            candidate_query = (
+                f"{table_name}{time_filter}{keyword_filter}"
+                f" | distinct {bracket_if_needed(group_column)}"
+                f" | take {intent['limit']}"
+            )
+            template = "distinct"
+        else:
+            candidate_query = (
+                f"{table_name}{time_filter}{keyword_filter}"
+                f" | summarize count_ = count() by {bracket_if_needed(group_column)}"
+                f" | top {intent['limit']} by count_ desc"
+            )
+            template = "aggregate"
+
+        candidates.append({
+            "template": template,
+            "query": candidate_query,
+            "columns_used": [column for column in [time_column, group_column, filter_column] if column],
+        })
+
+    if intent["needs_latest"] and time_column:
+        candidates.append({
+            "template": "latest",
+            "query": (
+                f"{table_name}{time_filter}{keyword_filter}"
+                f" | top {intent['limit']} by {bracket_if_needed(time_column)} desc"
+                f" | project {project_clause}"
+            ),
+            "columns_used": [column for column in [time_column, filter_column] if column] + output_columns,
+        })
+
+    candidates.append({
+        "template": "projection",
+        "query": f"{table_name}{time_filter}{keyword_filter} | project {project_clause} | take {intent['limit']}",
+        "columns_used": [column for column in [time_column, filter_column] if column] + output_columns,
+    })
+
+    deduped_candidates = []
+    seen_queries = set()
+    for candidate in candidates:
+        if candidate["query"] not in seen_queries:
+            seen_queries.add(candidate["query"])
+            deduped_candidates.append(candidate)
+    return deduped_candidates
+
+
+def _build_join_candidate(
+    candidate_tables: List[Dict[str, Any]],
+    join_hints: List[str],
+    intent: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Build a simple join candidate from stored join hints."""
+    if len(candidate_tables) < 2 or not join_hints or not intent.get("needs_join"):
+        return None
+
+    for join_hint in join_hints:
+        match = re.match(r"(.+?) joins with (.+?) on (.+)", join_hint)
+        if not match:
+            continue
+
+        left_table, right_table, join_column = match.groups()
+        left_info = next((table for table in candidate_tables if table["table"] == left_table), None)
+        right_info = next((table for table in candidate_tables if table["table"] == right_table), None)
+        if not left_info or not right_info:
+            continue
+
+        left_columns = _pick_generation_columns(left_info, intent)
+        right_columns = _pick_generation_columns(right_info, intent)
+        left_time_filter = _build_time_filter(intent, left_columns["time_column"])
+        projected_columns = []
+        for column in left_columns["output_columns"][:4] + right_columns["output_columns"][:4]:
+            if column != join_column and column not in projected_columns:
+                projected_columns.append(column)
+        project_clause = ", ".join(bracket_if_needed(column) for column in projected_columns[:8])
+
+        return {
+            "template": "join",
+            "table": left_table,
+            "query": (
+                f"{bracket_if_needed(left_table)}{left_time_filter}"
+                f" | join kind=inner {bracket_if_needed(right_table)} on {bracket_if_needed(join_column)}"
+                f" | project {project_clause}"
+                f" | take {intent['limit']}"
+            ),
+            "columns_used": [join_column] + projected_columns[:8],
+        }
+
+    return None
+
+
+def _score_generation_candidate(
+    candidate: Dict[str, Any],
+    table_info: Dict[str, Any],
+    intent: Dict[str, Any],
+) -> float:
+    """Score candidate queries before validation."""
+    score = float(table_info.get("score", 0.0)) * 2.0
+    template = candidate["template"]
+    query = candidate["query"].lower()
+
+    if intent["needs_trend"] and template == "trend":
+        score += 4.0
+    if intent["needs_count"] and template == "aggregate":
+        score += 3.5
+    if intent["needs_join"] and template == "join":
+        score += 4.0
+    if intent["needs_top"] and ("top " in query or template == "aggregate"):
+        score += 2.5
+    if intent["needs_latest"] and template == "latest":
+        score += 3.0
+    if intent["wants_distinct"] and template == "distinct":
+        score += 3.0
+    if intent["time_window"] and "| where " in query:
+        score += 1.25
+    score += min(len(candidate.get("columns_used", [])), 8) * 0.1
+    score -= max(len(query) - 240, 0) * 0.002
+    return round(score, 4)
+
+
+async def _validate_candidate_query(
+    candidate: Dict[str, Any],
+    cluster_url: str,
+    database: str,
+) -> Dict[str, Any]:
+    """Validate a generated candidate against cached schema."""
+    validation = await kql_validator.validate_query(
+        query=candidate["query"],
+        cluster=cluster_url,
+        database=database,
+        auto_discover=False,
+    )
+    validated_candidate = {**candidate, "validation": validation}
+    if validation.get("valid"):
+        validated_candidate["score"] = round(candidate["score"] + 5.0, 4)
+    else:
+        validated_candidate["score"] = round(candidate["score"] - len(validation.get("errors", [])) * 2.0, 4)
+    return validated_candidate
+
+
+def _build_safe_repair_query(
+    table_info: Dict[str, Any],
+    intent: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Fallback repair candidate that uses only the top ranked schema columns."""
+    column_plan = _pick_generation_columns(table_info, intent)
+    time_filter = _build_time_filter(intent, column_plan["time_column"])
+    project_clause = ", ".join(
+        bracket_if_needed(column) for column in column_plan["output_columns"][:6]
+    )
+    return {
+        "template": "repair_projection",
+        "query": (
+            f"{bracket_if_needed(table_info['table'])}{time_filter}"
+            f" | project {project_clause}"
+            f" | take {intent['limit']}"
+        ),
+        "columns_used": column_plan["output_columns"][:6],
+        "score": float(table_info.get("score", 0.0)),
+    }
 
 
 @mcp.tool()
@@ -89,6 +582,7 @@ async def execute_kql_query(
         JSON string with query results or generated query.
     """
     try:
+        repaired_query_info = None
         if not kusto_manager_global or not kusto_manager_global.get("authenticated"):
             return json.dumps({
                 "success": False,
@@ -115,14 +609,20 @@ async def execute_kql_query(
             if not generated_result["success"]:
                 return ErrorHandler.safe_json_dumps(generated_result, indent=2)
 
-            query = generated_result["query"]
+            query = generated_result.get("query_plain", generated_result["query"])
             if output_format == "generation_only":
                 return ErrorHandler.safe_json_dumps(generated_result, indent=2)
 
         # Check cache for non-generate queries (fast path)
         if not generate_query and output_format == "json":
             try:
-                cached = memory_manager.get_cached_result(query, ttl_seconds=120)
+                cached = memory_manager.get_cached_result(
+                    query,
+                    ttl_seconds=120,
+                    cluster=cluster_url,
+                    database=database,
+                    cache_namespace=f"execute:{output_format}",
+                )
                 if cached:
                     logger.info("Returning cached result for query")
                     return cached
@@ -137,17 +637,52 @@ async def execute_kql_query(
 
         if not validation_result["valid"]:
             logger.warning("Validation failed: %s", validation_result['errors'])
-            result = {
-                "success": False,
-                "error": "Query validation failed",
-                "validation_errors": validation_result["errors"],
-                "warnings": validation_result.get("warnings", []),
-                "suggestions": validation_result.get("suggestions", []),
-                "query": query[:200] + "..." if len(query) > 200 else query,
-                "requested_auth_method": requested_auth_method,
-                "active_auth_method": active_auth_method
-            }
-            return json.dumps(result, indent=2)
+            repaired_query_info = await _repair_query_with_schema_context(
+                query,
+                cluster_url,
+                database,
+                validation_result,
+            )
+            if repaired_query_info:
+                query = repaired_query_info["query"]
+                validation_result = await kql_validator.validate_query(
+                    query=query,
+                    cluster=cluster_url,
+                    database=database,
+                    auto_discover=False,
+                )
+                logger.info(
+                    "Schema-grounded repair succeeded for %s using replacements: %s",
+                    repaired_query_info["table_name"],
+                    repaired_query_info["replacements"],
+                )
+
+                if output_format == "generation_only":
+                    return ErrorHandler.safe_json_dumps({
+                        "success": True,
+                        "query": query,
+                        "query_plain": query,
+                        "repair_applied": True,
+                        "replacements": repaired_query_info["replacements"],
+                        "table_name": repaired_query_info["table_name"],
+                        "preferred_time_column": repaired_query_info["preferred_time_column"],
+                        "schema_columns": repaired_query_info["schema_columns"],
+                    }, indent=2)
+
+            if not validation_result["valid"]:
+                result = {
+                    "success": False,
+                    "error": "Query validation failed",
+                    "validation_errors": validation_result["errors"],
+                    "warnings": validation_result.get("warnings", []),
+                    "suggestions": validation_result.get("suggestions", []),
+                    "query": query[:200] + "..." if len(query) > 200 else query,
+                    "requested_auth_method": requested_auth_method,
+                    "active_auth_method": active_auth_method
+                }
+                return json.dumps(result, indent=2)
+
+        repair_metadata = None if generate_query else repaired_query_info
 
         logger.info("Query validated successfully. Tables: %s, Columns: %s", validation_result['tables_used'], validation_result['columns_validated'])
 
@@ -271,11 +806,23 @@ async def execute_kql_query(
                 "requested_auth_method": requested_auth_method,
                 "active_auth_method": active_auth_method
             }
+            if repair_metadata:
+                result["repair_applied"] = True
+                result["replacements"] = repair_metadata["replacements"]
+                result["schema_grounded_table"] = repair_metadata["table_name"]
+                result["preferred_time_column"] = repair_metadata["preferred_time_column"]
 
             # Cache successful result for future queries
             result_json = ErrorHandler.safe_json_dumps(result, indent=2)
             try:
-                memory_manager.cache_query_result(query, result_json, len(df))
+                memory_manager.cache_query_result(
+                    query,
+                    result_json,
+                    len(df),
+                    cluster=cluster_url,
+                    database=database,
+                    cache_namespace=f"execute:{output_format}",
+                )
             except Exception:
                 pass  # Don't fail on cache errors
 
@@ -323,136 +870,190 @@ async def _generate_kql_from_natural_language(
     - <CLUSTER>, <DATABASE>, <TABLE>, <COLUMN> tags for semantic clarity
     - <KQL> tags wrap the generated query for easy extraction
     """
-    from .constants import KQL_RESERVED_WORDS, SPECIAL_TOKENS
+    from .constants import SPECIAL_TOKENS
     
     try:
-        # 1. First, try to find relevant tables from schema memory using semantic search
-        relevant_tables = memory_manager.find_relevant_tables(cluster_url, database, natural_language_query, limit=5)
+        intent = _detect_generation_intent(natural_language_query)
+        cag_bundle = memory_manager.build_cag_bundle(
+            cluster_url,
+            database,
+            natural_language_query,
+            max_tables=3,
+            max_columns=12,
+        )
+        candidate_tables = list(cag_bundle.get("tables", []))
 
-        # 2. Determine target table from: explicit param > semantic search > NL extraction
-        target_table = None
         if table_name:
-            target_table = table_name
-        elif relevant_tables:
-            # Use the most relevant table from schema memory
-            target_table = relevant_tables[0]["table"]
-            logger.info("Selected table '%s' from schema memory (score: %.2f)",
-                       target_table, relevant_tables[0].get("score", 0))
-        else:
-            # Fallback: extract potential table name from NL query
-            potential_tables = re.findall(r'\b([A-Z][A-Za-z0-9_]*)\b', natural_language_query)
-            if potential_tables:
-                target_table = potential_tables[0]
+            schema_info = await schema_manager.get_table_schema(cluster_url, database, table_name)
+            if not schema_info or not schema_info.get("columns"):
+                return {
+                    "success": False,
+                    "error": f"No schema found for {SPECIAL_TOKENS['TABLE_START']}{table_name}{SPECIAL_TOKENS['TABLE_END']} in memory.",
+                    "query": "",
+                    "suggestion": f"Run: schema_memory(operation='discover', cluster_url='{cluster_url}', database='{database}', table_name='{table_name}')",
+                }
 
-        if not target_table:
+            explicit_table = {
+                "table": table_name,
+                "columns": schema_info["columns"],
+                "score": 100.0,
+                "matched_columns": [],
+                "datetime_columns": sum(
+                    1
+                    for column_def in schema_info["columns"].values()
+                    if isinstance(column_def, dict) and column_def.get("data_type") == "datetime"
+                ),
+            }
+            explicit_table["fingerprinted_columns"] = memory_manager.fingerprint_columns(
+                natural_language_query,
+                {"table": table_name, "columns": schema_info["columns"]},
+                similar_queries=cag_bundle.get("similar_queries", []),
+                max_columns=12,
+            )
+            explicit_table["selected_columns"] = {
+                column["name"]: schema_info["columns"][column["name"]]
+                for column in explicit_table["fingerprinted_columns"]
+                if column["name"] in schema_info["columns"]
+            }
+            candidate_tables = [explicit_table] + [
+                table for table in candidate_tables if table["table"].lower() != table_name.lower()
+            ]
+
+        if not candidate_tables:
             return {
                 "success": False,
-                "error": f"{SPECIAL_TOKENS['CLUSTER_START']}ERROR{SPECIAL_TOKENS['CLUSTER_END']} Could not determine target table.",
+                "error": f"{SPECIAL_TOKENS['CLUSTER_START']}ERROR{SPECIAL_TOKENS['CLUSTER_END']} Could not determine a relevant table from schema memory.",
                 "query": "",
-                "suggestion": "Use schema_memory tool to discover available tables before generating queries."
+                "suggestion": "Use schema_memory(operation='list_tables') or pass table_name explicitly before generating queries.",
             }
 
-        # 3. Get schema for the target table from schema memory (NOT hardcoded)
-        schema_info = await schema_manager.get_table_schema(cluster_url, database, target_table)
-        if not schema_info or not schema_info.get("columns"):
+        validated_candidates = []
+        join_candidate = _build_join_candidate(
+            candidate_tables[:2],
+            cag_bundle.get("join_hints", []),
+            intent,
+        )
+        if join_candidate:
+            join_candidate["score"] = _score_generation_candidate(
+                join_candidate,
+                candidate_tables[0],
+                intent,
+            )
+            validated_candidates.append(
+                await _validate_candidate_query(join_candidate, cluster_url, database)
+            )
+
+        for table_info in candidate_tables[:2]:
+            for candidate in _build_candidate_queries(table_info, intent):
+                candidate["table"] = table_info["table"]
+                candidate["score"] = _score_generation_candidate(candidate, table_info, intent)
+                validated_candidates.append(
+                    await _validate_candidate_query(candidate, cluster_url, database)
+                )
+
+        validated_candidates.sort(key=lambda item: item["score"], reverse=True)
+        best_candidate = next(
+            (candidate for candidate in validated_candidates if candidate["validation"].get("valid")),
+            validated_candidates[0] if validated_candidates else None,
+        )
+
+        if not best_candidate:
             return {
                 "success": False,
-                "error": f"No schema found for {SPECIAL_TOKENS['TABLE_START']}{target_table}{SPECIAL_TOKENS['TABLE_END']} in memory.",
+                "error": "No viable KQL candidate could be generated from the available schema context.",
                 "query": "",
-                "suggestion": f"Run: schema_memory(operation='discover', cluster_url='{cluster_url}', database='{database}', table_name='{target_table}')"
+                "suggestion": "Discover schema for the target table first, then retry with a narrower natural language request.",
             }
 
-        # 4. Build column mapping ONLY from schema memory (case-insensitive)
-        schema_columns = schema_info["columns"]
-        col_map = {c.lower(): c for c in schema_columns.keys()}
-        all_schema_columns = list(schema_columns.keys())  # Preserve order
-        
-        # Build set of reserved words for filtering (case-insensitive)
-        reserved_words_lower = {w.lower() for w in KQL_RESERVED_WORDS}
+        if not best_candidate["validation"].get("valid"):
+            repair_candidate = _build_safe_repair_query(candidate_tables[0], intent)
+            repair_candidate["table"] = candidate_tables[0]["table"]
+            repair_candidate = await _validate_candidate_query(repair_candidate, cluster_url, database)
+            if repair_candidate["validation"].get("valid"):
+                best_candidate = repair_candidate
 
-        # 5. Get CAG context (includes schema + similar queries + join hints from memory)
-        cag_context = memory_manager.get_relevant_context(cluster_url, database, natural_language_query)
-
-        # 6. Find similar successful queries from memory for pattern matching
-        similar_queries = memory_manager.find_similar_queries(cluster_url, database, natural_language_query, limit=3)
-
-        # 7. Extract ONLY columns that exist in schema memory
-        # First, extract all words from NL query that might be columns
-        nl_words = set(re.findall(r'\b([A-Za-z_][A-Za-z0-9_]*)\b', natural_language_query.lower()))
-        
-        # Filter out KQL reserved words before matching
-        nl_words = {w for w in nl_words if w not in reserved_words_lower}
-
-        # Also extract from similar queries (these are validated queries from memory)
-        for sq in similar_queries:
-            if sq.get('score', 0) > 0.5:  # Only use high-confidence matches
-                sq_words = re.findall(r'\b([A-Za-z_][A-Za-z0-9_]*)\b', sq.get('query', '').lower())
-                # Filter reserved words from similar queries too
-                sq_words = [w for w in sq_words if w not in reserved_words_lower]
-                nl_words.update(sq_words)
-
-        # 8. Match ONLY against schema columns (strict validation)
-        valid_columns = []
-        for word in nl_words:
-            if word in col_map:
-                actual_col = col_map[word]
-                # Double-check the column exists in schema (defensive)
-                if actual_col in schema_columns:
-                    valid_columns.append(actual_col)
-
-        # Remove duplicates while preserving order
-        valid_columns = list(dict.fromkeys(valid_columns))
-
-        # 9. Build query using ONLY validated schema data
-        if valid_columns:
-            # Limit to reasonable number of columns
-            project_cols = valid_columns[:12]
-            project_clause = ", ".join(bracket_if_needed(c) for c in project_cols)
-            final_query = f"{bracket_if_needed(target_table)} | project {project_clause} | take 10"
-            method = "schema_memory_validated"
-            columns_used = project_cols
-        else:
-            # Safe fallback: project first N columns from schema (NOT all columns)
-            # This ensures we always use schema-validated columns
-            default_cols = all_schema_columns[:10]  # First 10 schema columns
-            project_clause = ", ".join(bracket_if_needed(c) for c in default_cols)
-            final_query = f"{bracket_if_needed(target_table)} | project {project_clause} | take 10"
-            method = "schema_memory_fallback"
-            columns_used = default_cols
-            logger.info("No specific columns matched from NL query for '%s', using schema columns: %s", 
-                       target_table, default_cols)
-
-        # 10. Build structured response with special tokens for LLM parsing
-        # Format columns with special tokens for better semantic understanding
+        selected_table = next(
+            (table for table in candidate_tables if table["table"] == best_candidate["table"]),
+            candidate_tables[0],
+        )
+        valid_candidate_count = sum(
+            1 for candidate in validated_candidates if candidate["validation"].get("valid")
+        )
+        generation_metrics = {
+            "candidate_count": len(validated_candidates),
+            "valid_candidate_count": valid_candidate_count,
+            "repair_used": best_candidate["template"] == "repair_projection",
+            "table_candidate_count": len(candidate_tables[:2]),
+        }
+        selected_columns = _pick_generation_columns(selected_table, intent)["output_columns"]
+        schema_columns = selected_table.get("columns", {})
         columns_with_tokens = [
-            f"{SPECIAL_TOKENS['COLUMN']}:{col}|{SPECIAL_TOKENS['TYPE']}:{schema_columns.get(col, {}).get('data_type', 'unknown')}"
-            for col in columns_used
+            f"{SPECIAL_TOKENS['COLUMN']}:{column}|{SPECIAL_TOKENS['TYPE']}:{schema_columns.get(column, {}).get('data_type', 'unknown') if isinstance(schema_columns.get(column), dict) else schema_columns.get(column, 'unknown')}"
+            for column in selected_columns
         ]
-        
-        # Build schema context with tokens
         schema_context = (
             f"{SPECIAL_TOKENS['CLUSTER_START']}{cluster_url}{SPECIAL_TOKENS['CLUSTER_END']}"
             f"{SPECIAL_TOKENS['SEPARATOR']}"
             f"{SPECIAL_TOKENS['DATABASE_START']}{database}{SPECIAL_TOKENS['DATABASE_END']}"
             f"{SPECIAL_TOKENS['SEPARATOR']}"
-            f"{SPECIAL_TOKENS['TABLE_START']}{target_table}{SPECIAL_TOKENS['TABLE_END']}"
+            f"{SPECIAL_TOKENS['TABLE_START']}{selected_table['table']}{SPECIAL_TOKENS['TABLE_END']}"
         )
+
+        try:
+            memory_manager.store_learning_result(
+                natural_language_query,
+                {
+                    "target_table": selected_table["table"],
+                    "query": best_candidate["query"],
+                    "generation_metrics": generation_metrics,
+                    "ranked_tables": [table["table"] for table in candidate_tables[:3]],
+                },
+                execution_type="generation",
+            )
+        except Exception as learning_error:  # pylint: disable=broad-exception-caught
+            logger.debug("Failed to store generation telemetry: %s", learning_error)
 
         return {
             "success": True,
-            "query": f"{SPECIAL_TOKENS['QUERY_START']}{final_query}{SPECIAL_TOKENS['QUERY_END']}",
-            "query_plain": final_query,  # Plain query without tokens for direct execution
-            "generation_method": method,
-            "target_table": target_table,
-            "schema_validated": True,
-            "columns_used": columns_used,
+            "query": best_candidate["query"],
+            "query_plain": best_candidate["query"],
+            "query_tagged": f"{SPECIAL_TOKENS['QUERY_START']}{best_candidate['query']}{SPECIAL_TOKENS['QUERY_END']}",
+            "generation_method": "cag_hybrid_ranking",
+            "target_table": selected_table["table"],
+            "schema_validated": best_candidate["validation"].get("valid", False),
+            "validation_errors": best_candidate["validation"].get("errors", []),
+            "columns_used": selected_columns,
             "columns_with_types": columns_with_tokens,
-            "total_schema_columns": len(all_schema_columns),
-            "available_columns": all_schema_columns[:20],
-            "similar_queries_found": len(similar_queries),
-            "cag_context_used": bool(cag_context),
+            "ranked_tables": [
+                {
+                    "table": table["table"],
+                    "score": table.get("score", 0.0),
+                    "matched_columns": table.get("matched_columns", []),
+                    "top_columns": [column["name"] for column in table.get("fingerprinted_columns", [])[:6]],
+                }
+                for table in candidate_tables[:3]
+            ],
+            "candidate_queries": [
+                {
+                    "table": candidate["table"],
+                    "template": candidate["template"],
+                    "score": candidate["score"],
+                    "valid": candidate["validation"].get("valid", False),
+                    "query": candidate["query"],
+                }
+                for candidate in validated_candidates[:4]
+            ],
+            "generation_metrics": generation_metrics,
+            "similar_queries_found": len(cag_bundle.get("similar_queries", [])),
+            "cag_context_used": bool(cag_bundle.get("context")),
+            "cag_context": cag_bundle.get("context", ""),
             "schema_context": schema_context,
-            "note": f"{SPECIAL_TOKENS['AI_START']}Query generated using ONLY schema-validated columns. All projected columns exist in table schema.{SPECIAL_TOKENS['AI_END']}"
+            "note": (
+                f"{SPECIAL_TOKENS['AI_START']}"
+                "Query generated from compact CAG retrieval, hybrid table/column ranking, "
+                "candidate reranking, and schema validation."
+                f"{SPECIAL_TOKENS['AI_END']}"
+            ),
         }
 
     except (ValueError, KeyError, RuntimeError) as e:
@@ -491,6 +1092,9 @@ async def schema_memory(
     - "get_stats": Get memory and cache statistics
     - "clear_cache": Clear all cached schemas
     - "generate_report": Generate analysis report with visualizations
+    - "cache_stats": Get detailed query cache statistics (NEW)
+    - "cleanup_cache": Remove expired cache entries (NEW)
+    - "list_multi_cluster_tables": List tables found in multiple clusters (NEW)
 
     Args:
         operation: The operation to perform (see list above)
@@ -537,7 +1141,7 @@ async def schema_memory(
                     "success": False,
                     "error": "cluster_url, database, and natural_language_query are required for get_context operation"
                 })
-            return await _schema_get_context_operation(cluster_url, database, natural_language_query)
+            return await _schema_get_context_operation(cluster_url, database, natural_language_query, table_name)
         elif operation == "generate_report":
             return await _schema_generate_report_operation(session_id, include_visualizations)
         elif operation == "clear_cache":
@@ -551,11 +1155,21 @@ async def schema_memory(
                     "error": "cluster_url and database are required for refresh_schema operation"
                 })
             return await _schema_refresh_operation(cluster_url, database)
+        elif operation == "cache_stats":
+            return await _schema_cache_stats_operation()
+        elif operation == "cleanup_cache":
+            return await _schema_cleanup_cache_operation()
+        elif operation == "list_multi_cluster_tables":
+            return await _schema_list_multi_cluster_tables_operation()
         else:
             return json.dumps({
                 "success": False,
                 "error": f"Unknown operation: {operation}",
-                "available_operations": ["discover", "list_tables", "get_context", "generate_report", "clear_cache", "get_stats", "refresh_schema"]
+                "available_operations": [
+                    "discover", "list_tables", "get_context", "generate_report", 
+                    "clear_cache", "get_stats", "refresh_schema",
+                    "cache_stats", "cleanup_cache", "list_multi_cluster_tables"
+                ]
             })
 
     except (ValueError, KeyError, RuntimeError) as e:
@@ -849,7 +1463,12 @@ async def _schema_list_tables_operation(cluster_url: str, database: str) -> str:
             "error": str(e)
         })
 
-async def _schema_get_context_operation(cluster_url: str, database: str, natural_language_query: str) -> str:
+async def _schema_get_context_operation(
+    cluster_url: str,
+    database: str,
+    natural_language_query: str,
+    table_name: Optional[str] = None,
+) -> str:
     """Get AI context for tables based on natural language query parsing."""
     try:
         if not natural_language_query:
@@ -857,23 +1476,69 @@ async def _schema_get_context_operation(cluster_url: str, database: str, natural
                 "success": False,
                 "error": "natural_language_query is required for get_context operation"
             })
+        if table_name:
+            schema_info = await schema_manager.get_table_schema(cluster_url, database, table_name)
+            if not schema_info or not schema_info.get("columns"):
+                return json.dumps({
+                    "success": False,
+                    "error": f"No schema found for table '{table_name}'"
+                })
 
-        # Simple table extraction instead of undefined query_processor
-        # Note: 're' is already imported at module level
-        # Look for words starting with capital letters that might be tables, or just use the whole query as context
-        # For now, let's try to extract potential table names using a simple regex
-        potential_tables = re.findall(r'\b[A-Z][a-zA-Z0-9_]*\b', natural_language_query)
-        tables = list(set(potential_tables))
-
-        if not tables:
-            # If no specific tables found, we might still want context for the whole database
-            # But the original code required tables. Let's fallback to a generic context request.
-            pass
-
-        context = memory_manager.get_ai_context_for_tables(cluster_url, database, tables)
+            similar_queries = memory_manager.find_similar_queries(
+                cluster_url, database, natural_language_query, limit=3
+            )
+            fingerprinted_columns = memory_manager.fingerprint_columns(
+                natural_language_query,
+                {"table": table_name, "columns": schema_info["columns"]},
+                similar_queries=similar_queries,
+                max_columns=12,
+            )
+            selected_columns = {
+                column["name"]: schema_info["columns"][column["name"]]
+                for column in fingerprinted_columns
+                if column["name"] in schema_info["columns"]
+            }
+            join_hints = memory_manager.get_join_hints([table_name])
+            cag_bundle = {
+                "tables": [{
+                    "table": table_name,
+                    "score": 100.0,
+                    "columns": schema_info["columns"],
+                    "fingerprinted_columns": fingerprinted_columns,
+                    "selected_columns": selected_columns,
+                }],
+                "similar_queries": similar_queries,
+                "join_hints": join_hints,
+                "context": memory_manager._to_toon(  # pylint: disable=protected-access
+                    [{"table": table_name, "columns": selected_columns}],
+                    similar_queries,
+                    join_hints,
+                ),
+            }
+        else:
+            cag_bundle = memory_manager.build_cag_bundle(
+                cluster_url,
+                database,
+                natural_language_query,
+                max_tables=3,
+                max_columns=12,
+            )
+        tables = [table["table"] for table in cag_bundle.get("tables", [])]
+        context = cag_bundle.get("context", "")
         return json.dumps({
             "success": True,
             "tables": tables,
+            "ranked_tables": cag_bundle.get("tables", []),
+            "similar_queries": cag_bundle.get("similar_queries", []),
+            "join_hints": cag_bundle.get("join_hints", []),
+            "strict_schema": {
+                table["table"]: {
+                    "allowed_columns": list((table.get("columns") or {}).keys())[:50],
+                    "recommended_columns": [column["name"] for column in table.get("fingerprinted_columns", [])[:12]],
+                    "preferred_time_column": _choose_preferred_time_column(table.get("columns") or {}),
+                }
+                for table in cag_bundle.get("tables", [])
+            },
             "context": context
         }, indent=2)
     except (ValueError, RuntimeError, AttributeError) as e:
@@ -921,15 +1586,14 @@ async def _schema_generate_report_operation(session_id: str, include_visualizati
 async def _schema_clear_cache_operation() -> str:
     """Clear schema cache (LRU for get_schema)."""
     try:
-        # Clear the LRU cache on get_schema if it exists
-        # MemoryManager uses SQLite, so we might not have an LRU cache on the method itself anymore.
-        # If we want to clear internal caches, we should add a method to MemoryManager.
-        # For now, we'll just log that we are clearing.
-        logger.info("Schema cache clear requested")
+        schema_manager.clear_schema_cache()
+        removed_query_cache = memory_manager.clear_query_cache()
+        logger.info("Schema and query cache clear requested")
 
         return json.dumps({
             "success": True,
-            "message": "Schema cache cleared successfully"
+            "message": "Schema and query cache cleared successfully",
+            "query_cache_entries_removed": removed_query_cache,
         })
     except (ValueError, RuntimeError, AttributeError) as e:
         return json.dumps({
@@ -1036,6 +1700,76 @@ async def _schema_refresh_operation(cluster_url: str, database: str) -> str:
         return json.dumps({
             "success": False,
             "error": f"Schema refresh failed: {str(e)}"
+        })
+
+
+async def _schema_cache_stats_operation() -> str:
+    """Get detailed query cache statistics."""
+    try:
+        cache_stats = memory_manager.get_cache_stats()
+        return json.dumps({
+            "success": True,
+            "cache_stats": cache_stats,
+            "description": {
+                "total_cached": "Total number of cached query results",
+                "expired_entries": "Number of expired cache entries awaiting cleanup",
+                "by_query_type": "Breakdown by query type (schema, aggregation, realtime, etc.)",
+                "ttl_settings": {
+                    "schema": "3600s (1 hour) - Schema queries",
+                    "aggregation": "600s (10 minutes) - Aggregation queries",
+                    "realtime": "60s (1 minute) - Real-time queries",
+                    "default": "300s (5 minutes) - Other queries"
+                }
+            }
+        }, indent=2)
+    except (ValueError, RuntimeError, AttributeError) as e:
+        return json.dumps({
+            "success": False,
+            "error": str(e)
+        })
+
+
+async def _schema_cleanup_cache_operation() -> str:
+    """Remove expired cache entries."""
+    try:
+        removed_count = memory_manager.cleanup_expired_cache()
+        return json.dumps({
+            "success": True,
+            "message": "Cache cleanup completed",
+            "entries_removed": removed_count,
+            "timestamp": datetime.now().isoformat()
+        }, indent=2)
+    except (ValueError, RuntimeError, AttributeError) as e:
+        return json.dumps({
+            "success": False,
+            "error": str(e)
+        })
+
+
+async def _schema_list_multi_cluster_tables_operation() -> str:
+    """List all tables with their known cluster/database locations."""
+    try:
+        all_locations = memory_manager.get_all_table_locations()
+        
+        # Identify tables in multiple clusters
+        multi_cluster_tables = {
+            table: locations 
+            for table, locations in all_locations.items() 
+            if len(set(loc["cluster"] for loc in locations)) > 1
+        }
+        
+        return json.dumps({
+            "success": True,
+            "total_tables_tracked": len(all_locations),
+            "multi_cluster_tables_count": len(multi_cluster_tables),
+            "multi_cluster_tables": multi_cluster_tables,
+            "all_table_locations": all_locations,
+            "note": "Tables in multiple clusters may have different schemas or data"
+        }, indent=2)
+    except (ValueError, RuntimeError, AttributeError) as e:
+        return json.dumps({
+            "success": False,
+            "error": str(e)
         })
 
 

--- a/mcp_kql_server/memory.py
+++ b/mcp_kql_server/memory.py
@@ -14,6 +14,7 @@ import sqlite3
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -44,6 +45,21 @@ TOON_TYPE_MAP = {
     'boolean': 'b',
     'dynamic': 'dyn',
     'guid': 'g'
+}
+
+RANKING_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "get",
+    "how", "i", "in", "into", "is", "it", "last", "latest", "list", "me",
+    "most", "of", "on", "or", "recent", "show", "table", "that", "the",
+    "their", "them", "these", "those", "to", "top", "what", "which", "with"
+}
+
+RANKING_TOKEN_SYNONYMS = {
+    "user": {"user", "users", "account", "accounts", "principal", "identity", "upn"},
+    "signin": {"signin", "signins", "login", "logon", "auth", "authentication"},
+    "alert": {"alert", "alerts", "severity", "incident"},
+    "device": {"device", "devices", "host", "hosts", "computer", "machine"},
+    "process": {"process", "processes", "command", "cmd"},
 }
 
 class SemanticSearch:
@@ -83,7 +99,7 @@ class SemanticSearch:
                     if SentenceTransformer:
                         self.model = SentenceTransformer(self.model_name)
                     logger.info("Loaded Semantic Search model: %s", self.model_name)
-                except Exception as e:
+                except (OSError, RuntimeError, ValueError) as e:
                     logger.warning("Failed to load SentenceTransformer: %s", e)
                 finally:
                     self._loading = False
@@ -101,7 +117,7 @@ class SemanticSearch:
             if not isinstance(embedding, np.ndarray):
                 embedding = np.array(embedding)
             return embedding.astype(np.float32).tobytes()
-        except Exception as e:
+        except (RuntimeError, ValueError, TypeError) as e:
             logger.error("Encoding failed: %s", e)
             return None
 
@@ -189,13 +205,28 @@ class MemoryManager:
                 )
             """)
 
-            # Query Cache table: Stores result hashes
+            # Query Cache table: Stores result hashes with configurable TTL
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS query_cache (
                     query_hash TEXT PRIMARY KEY,
                     result_json TEXT,
                     timestamp TIMESTAMP,
-                    row_count INTEGER
+                    row_count INTEGER,
+                    query_type TEXT DEFAULT 'default',
+                    ttl_seconds INTEGER DEFAULT 300,
+                    cluster TEXT,
+                    database TEXT
+                )
+            """)
+
+            # Multi-cluster table registry
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS table_locations (
+                    table_name TEXT,
+                    cluster TEXT,
+                    database TEXT,
+                    last_seen TIMESTAMP,
+                    PRIMARY KEY (table_name, cluster, database)
                 )
             """)
 
@@ -203,6 +234,9 @@ class MemoryManager:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_schemas_db ON schemas(cluster, database)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_queries_db ON queries(cluster, database)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_join_hints ON join_hints(table1, table2)")
+
+            # Run schema migrations for existing databases
+            self._migrate_schema(conn)
 
             # Learning Events table: Stores execution learning data
             conn.execute("""
@@ -216,10 +250,46 @@ class MemoryManager:
                 )
             """)
 
+    def _migrate_schema(self, conn: sqlite3.Connection):
+        """
+        Migrate existing database schema to add new columns.
+        This handles backwards compatibility for databases created before v2.1.1.
+        """
+        # Check for query_cache table columns and add if missing
+        try:
+            cursor = conn.execute("PRAGMA table_info(query_cache)")
+            existing_columns = {row[1] for row in cursor.fetchall()}
+            
+            # Add new columns to query_cache if they don't exist
+            if 'query_type' not in existing_columns:
+                conn.execute("ALTER TABLE query_cache ADD COLUMN query_type TEXT DEFAULT 'default'")
+                logger.info("Migration: Added query_type column to query_cache")
+            
+            if 'ttl_seconds' not in existing_columns:
+                conn.execute("ALTER TABLE query_cache ADD COLUMN ttl_seconds INTEGER DEFAULT 300")
+                logger.info("Migration: Added ttl_seconds column to query_cache")
+            
+            if 'cluster' not in existing_columns:
+                conn.execute("ALTER TABLE query_cache ADD COLUMN cluster TEXT")
+                logger.info("Migration: Added cluster column to query_cache")
+            
+            if 'database' not in existing_columns:
+                conn.execute("ALTER TABLE query_cache ADD COLUMN database TEXT")
+                logger.info("Migration: Added database column to query_cache")
+                
+            conn.commit()
+        except sqlite3.OperationalError as e:
+            logger.debug("Migration check for query_cache: %s", e)
+
     def store_schema(self, cluster: str, database: str, table: str,
                      schema: Dict[str, Any], description: Optional[str] = None):
         """Store or update a table schema with embedding and description."""
         columns = schema.get("columns", {})
+        if not columns and schema:
+            # Accept either {"columns": {...}} or a raw {column_name: column_def} mapping.
+            columns = schema
+
+        normalized_cluster = self.normalize_cluster_uri(cluster)
 
         # Normalize columns to dict format if it's a list
         if isinstance(columns, list):
@@ -232,10 +302,6 @@ class MemoryManager:
                 elif isinstance(col, str):
                     normalized_cols[col] = {"data_type": "string"}
             columns = normalized_cols
-
-        # Generate embedding for table (name + column names)
-        col_names = " ".join(columns.keys())
-        embedding = self.semantic_search.encode(f"Table {table} contains columns: {col_names}")
 
         with self._lock, sqlite3.connect(self.db_path) as conn:
             # Check if columns exist (migration for existing DBs)
@@ -253,24 +319,56 @@ class MemoryManager:
             if description is None:
                 cursor = conn.execute(
                     "SELECT description FROM schemas WHERE cluster=? AND database=? AND table_name=?",
-                    (cluster, database, table)
+                    (normalized_cluster, database, table)
                 )
                 row = cursor.fetchone()
                 if row:
                     description = row[0]
 
+            existing_row = conn.execute(
+                """
+                SELECT columns_json, description
+                FROM schemas
+                WHERE cluster=? AND database=? AND table_name=?
+                """,
+                (normalized_cluster, database, table)
+            ).fetchone()
+
+            existing_columns = json.loads(existing_row[0]) if existing_row and existing_row[0] else {}
+            if not columns and existing_columns:
+                # Avoid overwriting a rich cached schema with an empty placeholder.
+                self.register_table_location(table, normalized_cluster, database)
+                logger.debug("Skipping empty schema overwrite for %s in %s", table, database)
+                return
+
+            if existing_columns == columns and (description == (existing_row[1] if existing_row else description)):
+                self.register_table_location(table, normalized_cluster, database)
+                logger.debug("Schema already indexed for %s in %s, skipping reindex", table, database)
+                return
+
+        # Generate embedding only when the schema is genuinely changing.
+        col_names = " ".join(columns.keys())
+        embedding = self.semantic_search.encode(f"Table {table} contains columns: {col_names}")
+
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+
             conn.execute("""
                 INSERT OR REPLACE INTO schemas
                 (cluster, database, table_name, columns_json, embedding, description, last_updated)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (cluster, database, table, json.dumps(columns),
+            """, (normalized_cluster, database, table, json.dumps(columns),
                   embedding, description, datetime.now().isoformat()))
 
+        cache_key = f"db_schema_{normalized_cluster}_{database}"
+        if hasattr(self, '_schema_cache'):
+            self._schema_cache.pop(cache_key, None)
+        self.register_table_location(table, normalized_cluster, database)
         logger.debug("Stored schema for %s in %s", table, database)
 
     def add_successful_query(self, cluster: str, database: str, query: str,
                              description: str, execution_time_ms: float = 0.0):
         """Store a successful query with its description and embedding."""
+        normalized_cluster = self.normalize_cluster_uri(cluster)
         embedding = self.semantic_search.encode(f"{description} {query}")
 
         with self._lock, sqlite3.connect(self.db_path) as conn:
@@ -284,7 +382,7 @@ class MemoryManager:
                 INSERT INTO queries
                 (cluster, database, query, description, embedding, timestamp, execution_time_ms)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (cluster, database, query, description, embedding,
+            """, (normalized_cluster, database, query, description, embedding,
                   datetime.now().isoformat(), execution_time_ms))
 
     def add_global_successful_query(self, cluster: str, database: str, query: str,
@@ -312,6 +410,7 @@ class MemoryManager:
     def find_relevant_tables(self, cluster: str, database: str,
                              query: str, limit: int = 5) -> List[Dict[str, Any]]:
         """Find tables semantically related to the query."""
+        normalized_cluster = self.normalize_cluster_uri(cluster)
         query_embedding = self.semantic_search.encode(query)
         if query_embedding is None:
             return []
@@ -322,7 +421,7 @@ class MemoryManager:
         with self._lock, sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
                 "SELECT table_name, columns_json, embedding FROM schemas WHERE cluster = ? AND database = ?",
-                (cluster, database)
+                (normalized_cluster, database)
             )
 
             for row in cursor:
@@ -344,6 +443,7 @@ class MemoryManager:
     def find_similar_queries(self, cluster: str, database: str,
                                query: str, limit: int = 3) -> List[Dict[str, Any]]:
         """Find similar past queries using vector search."""
+        normalized_cluster = self.normalize_cluster_uri(cluster)
         query_embedding = self.semantic_search.encode(query)
         if query_embedding is None:
             return []
@@ -355,7 +455,7 @@ class MemoryManager:
         with self._lock, sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
                 "SELECT query, description, embedding FROM queries WHERE cluster = ? AND database = ?",
-                (cluster, database)
+                (normalized_cluster, database)
             )
 
             for row in cursor:
@@ -374,33 +474,413 @@ class MemoryManager:
         results.sort(key=lambda x: x["score"], reverse=True)
         return results[:limit]
 
-    def cache_query_result(self, query: str, result_json: str, row_count: int):
-        """Cache query result."""
+    def _tokenize_ranking_text(self, text: str) -> List[str]:
+        """Tokenize free text and identifiers for retrieval/ranking heuristics."""
+        normalized = re.sub(r'([a-z0-9])([A-Z])', r'\1 \2', text or "")
+        tokens = re.findall(r'[A-Za-z_][A-Za-z0-9_]*', normalized.lower())
+        return [token for token in tokens if len(token) > 1 and token not in RANKING_STOPWORDS]
+
+    def _expand_query_tokens(self, tokens: List[str]) -> List[str]:
+        """Expand query tokens with a few high-value domain synonyms."""
+        expanded = set(tokens)
+        for token in list(expanded):
+            normalized = token[:-1] if token.endswith("s") else token
+            expanded.add(normalized)
+            for synonyms in RANKING_TOKEN_SYNONYMS.values():
+                if token in synonyms or normalized in synonyms:
+                    expanded.update(synonyms)
+        return list(expanded)
+
+    def _column_data_type(self, column_def: Any) -> str:
+        """Get a normalized column data type string."""
+        if isinstance(column_def, dict):
+            return str(column_def.get("data_type") or column_def.get("type") or "string").lower()
+        if isinstance(column_def, str):
+            return column_def.lower()
+        return "string"
+
+    def rank_tables_for_query(
+        self,
+        cluster: str,
+        database: str,
+        query: str,
+        limit: int = 5
+    ) -> List[Dict[str, Any]]:
+        """
+        Rank tables using hybrid lexical + semantic signals.
+
+        This provides a more reliable fallback when embeddings are unavailable and
+        keeps retrieval grounded in schema tokens and past successful queries.
+        """
+        schemas = self._get_database_schema(cluster, database)
+        if not schemas:
+            return []
+
+        semantic_scores = {
+            row["table"]: float(row.get("score", 0.0))
+            for row in self.find_relevant_tables(cluster, database, query, limit=max(limit * 3, 8))
+        }
+        similar_queries = self.find_similar_queries(cluster, database, query, limit=5)
+        query_tokens = set(self._expand_query_tokens(self._tokenize_ranking_text(query)))
+        query_lower = query.lower()
+        time_intent = any(
+            marker in query_lower
+            for marker in ("ago", "hour", "hours", "day", "days", "week", "weeks", "month",
+                           "months", "today", "yesterday", "recent", "latest", "trend", "over time")
+        )
+
+        ranked_tables = []
+        for schema in schemas:
+            table_name = schema["table"]
+            columns = schema.get("columns", {})
+            table_tokens = set(self._tokenize_ranking_text(table_name))
+            matched_columns = []
+            datetime_columns = 0
+
+            for column_name, column_def in columns.items():
+                column_tokens = set(self._tokenize_ranking_text(column_name))
+                overlap = query_tokens & column_tokens
+                if overlap:
+                    matched_columns.append(column_name)
+                if self._column_data_type(column_def) == "datetime":
+                    datetime_columns += 1
+
+            direct_table_mention = table_name.lower() in query_lower
+            semantic_score = semantic_scores.get(table_name, 0.0)
+            lexical_overlap = len(query_tokens & table_tokens)
+            column_overlap = len(matched_columns)
+            history_boost = sum(
+                1.0 for sq in similar_queries if table_name.lower() in sq.get("query", "").lower()
+            )
+            score = (
+                (4.5 if direct_table_mention else 0.0) +
+                lexical_overlap * 1.75 +
+                min(column_overlap, 6) * 0.9 +
+                semantic_score * 4.0 +
+                min(history_boost, 2.0) * 0.8 +
+                (0.75 if time_intent and datetime_columns else 0.0)
+            )
+
+            ranked_tables.append({
+                "table": table_name,
+                "columns": columns,
+                "score": round(score, 4),
+                "semantic_score": round(semantic_score, 4),
+                "matched_columns": matched_columns[:8],
+                "datetime_columns": datetime_columns,
+            })
+
+        ranked_tables.sort(
+            key=lambda item: (item["score"], len(item["matched_columns"]), item["table"].lower()),
+            reverse=True
+        )
+        return ranked_tables[:limit]
+
+    def fingerprint_columns(
+        self,
+        nl_query: str,
+        schema: Dict[str, Any],
+        similar_queries: Optional[List[Dict[str, Any]]] = None,
+        max_columns: int = 12
+    ) -> List[Dict[str, Any]]:
+        """
+        Rank the most relevant columns for an NL query.
+
+        The output is intentionally compact so the generator can build smaller
+        CAG prompts and more focused candidate queries.
+        """
+        columns = schema.get("columns", {}) or {}
+        if not columns:
+            return []
+
+        query_tokens = set(self._expand_query_tokens(self._tokenize_ranking_text(nl_query)))
+        query_lower = nl_query.lower()
+        time_intent = any(
+            marker in query_lower
+            for marker in ("ago", "hour", "hours", "day", "days", "week", "weeks", "month",
+                           "months", "today", "yesterday", "recent", "latest", "trend", "time")
+        )
+        aggregate_intent = any(
+            marker in query_lower
+            for marker in ("count", "how many", "total", "group", "per ", " by ", "top", "most", "trend")
+        )
+
+        history_hits: Dict[str, int] = {}
+        for similar_query in similar_queries or []:
+            for token in self._tokenize_ranking_text(similar_query.get("query", "")):
+                history_hits[token] = history_hits.get(token, 0) + 1
+
+        ranked_columns = []
+        for column_name, column_def in columns.items():
+            data_type = self._column_data_type(column_def)
+            column_tokens = set(self._tokenize_ranking_text(column_name))
+            overlap = query_tokens & column_tokens
+            exact_match = column_name.lower() in query_lower
+            history_score = history_hits.get(column_name.lower(), 0)
+            score = (
+                (5.0 if exact_match else 0.0) +
+                len(overlap) * 1.8 +
+                min(history_score, 3) * 0.75
+            )
+
+            if time_intent and (
+                data_type == "datetime" or {"time", "date", "timestamp"} & column_tokens
+            ):
+                score += 2.5
+
+            if aggregate_intent and data_type in {"string", "guid"}:
+                score += 1.0
+
+            if column_name.lower() in {"timegenerated", "timestamp", "reporttime"}:
+                score += 1.5
+
+            ranked_columns.append({
+                "name": column_name,
+                "data_type": data_type,
+                "score": round(score, 4),
+                "matched_terms": sorted(overlap),
+            })
+
+        ranked_columns.sort(
+            key=lambda item: (item["score"], item["data_type"] == "datetime", item["name"].lower()),
+            reverse=True
+        )
+
+        top_columns = ranked_columns[:max_columns]
+        if not any(column["score"] > 0 for column in top_columns):
+            return [
+                {
+                    "name": column_name,
+                    "data_type": self._column_data_type(columns[column_name]),
+                    "score": 0.0,
+                    "matched_terms": [],
+                }
+                for column_name in list(columns.keys())[:max_columns]
+            ]
+        return top_columns
+
+    def build_cag_bundle(
+        self,
+        cluster: str,
+        database: str,
+        user_query: str,
+        max_tables: int = 3,
+        max_columns: int = 12
+    ) -> Dict[str, Any]:
+        """
+        Build compact CAG context for generation and ranking.
+
+        Returns ranked tables, column fingerprints, similar queries, join hints,
+        and a compact TOON context string.
+        """
+        similar_queries = self.find_similar_queries(cluster, database, user_query, limit=3)
+        ranked_tables = self.rank_tables_for_query(cluster, database, user_query, limit=max_tables)
+
+        compact_schemas = []
+        enriched_tables = []
+        for table_info in ranked_tables:
+            fingerprinted_columns = self.fingerprint_columns(
+                user_query,
+                {"table": table_info["table"], "columns": table_info["columns"]},
+                similar_queries=similar_queries,
+                max_columns=max_columns,
+            )
+            selected_columns = {
+                column["name"]: table_info["columns"][column["name"]]
+                for column in fingerprinted_columns
+                if column["name"] in table_info["columns"]
+            }
+            enriched_tables.append({
+                **table_info,
+                "fingerprinted_columns": fingerprinted_columns,
+                "selected_columns": selected_columns,
+            })
+            compact_schemas.append({
+                "table": table_info["table"],
+                "columns": selected_columns,
+            })
+
+        join_hints = self.get_join_hints([table["table"] for table in ranked_tables]) if ranked_tables else []
+        return {
+            "tables": enriched_tables,
+            "similar_queries": similar_queries,
+            "join_hints": join_hints,
+            "context": self._to_toon(compact_schemas, similar_queries, join_hints),
+        }
+
+    def _build_cache_key(
+        self,
+        query: str,
+        cluster: Optional[str] = None,
+        database: Optional[str] = None,
+        cache_namespace: str = "default",
+    ) -> str:
+        """Build a cache key scoped to query text and execution context."""
         import hashlib
-        query_hash = hashlib.sha256(query.encode()).hexdigest()
+
+        normalized_cluster = self.normalize_cluster_uri(cluster or "")
+        payload = "||".join([
+            cache_namespace or "default",
+            normalized_cluster,
+            database or "",
+            query,
+        ])
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def cache_query_result(
+        self,
+        query: str,
+        result_json: str,
+        row_count: int,
+        query_type: str = "default",
+        ttl_seconds: int = 300,
+        cluster: Optional[str] = None,
+        database: Optional[str] = None,
+        cache_namespace: str = "default",
+    ):
+        """
+        Cache query result with configurable TTL per query type.
+        
+        Args:
+            query: The KQL query string
+            result_json: JSON-serialized query results
+            row_count: Number of rows in result
+            query_type: Type of query for TTL configuration (default, schema, aggregation, realtime)
+            ttl_seconds: Time-to-live in seconds (default: 300)
+            cluster: Cluster URL for multi-cluster tracking
+            database: Database name for multi-cluster tracking
+        
+        Query Type TTL Guidelines:
+            - 'schema': 3600s (1 hour) - table schemas change infrequently
+            - 'aggregation': 600s (10 min) - aggregate queries can be cached longer
+            - 'realtime': 60s (1 min) - time-sensitive queries
+            - 'default': 300s (5 min) - standard caching
+        """
+        query_hash = self._build_cache_key(
+            query,
+            cluster=cluster,
+            database=database,
+            cache_namespace=cache_namespace,
+        )
+
+        # Apply query type TTL overrides
+        ttl_map = {
+            "schema": 3600,
+            "aggregation": 600,
+            "realtime": 60,
+            "default": 300
+        }
+        effective_ttl = ttl_map.get(query_type, ttl_seconds)
+        normalized_cluster = self.normalize_cluster_uri(cluster or "") if cluster else None
 
         with self._lock, sqlite3.connect(self.db_path) as conn:
             conn.execute("""
-                INSERT OR REPLACE INTO query_cache (query_hash, result_json, timestamp, row_count)
-                VALUES (?, ?, ?, ?)
-            """, (query_hash, result_json, datetime.now().isoformat(), row_count))
+                INSERT OR REPLACE INTO query_cache 
+                (query_hash, result_json, timestamp, row_count, query_type, ttl_seconds, cluster, database)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (query_hash, result_json, datetime.now().isoformat(), row_count,
+                  query_type, effective_ttl, normalized_cluster, database))
 
-    def get_cached_result(self, query: str, ttl_seconds: int = 300) -> Optional[str]:
-        """Get cached result if valid."""
-        import hashlib
-        query_hash = hashlib.sha256(query.encode()).hexdigest()
+    def get_cached_result(
+        self,
+        query: str,
+        ttl_seconds: Optional[int] = None,
+        cluster: Optional[str] = None,
+        database: Optional[str] = None,
+        cache_namespace: str = "default",
+    ) -> Optional[str]:
+        """
+        Get cached result if valid, respecting stored TTL.
+        
+        Args:
+            query: The KQL query string
+            ttl_seconds: Override TTL (if None, uses stored TTL from cache entry)
+        
+        Returns:
+            Cached result JSON string, or None if not cached or expired
+        """
+        query_hash = self._build_cache_key(
+            query,
+            cluster=cluster,
+            database=database,
+            cache_namespace=cache_namespace,
+        )
 
         with self._lock, sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
-                "SELECT result_json, timestamp FROM query_cache WHERE query_hash = ?",
+                "SELECT result_json, timestamp, ttl_seconds FROM query_cache WHERE query_hash = ?",
                 (query_hash,)
             )
             row = cursor.fetchone()
             if row:
                 cached_time = datetime.fromisoformat(row[1])
-                if (datetime.now() - cached_time).total_seconds() < ttl_seconds:
+                # Use provided TTL or stored TTL, default to 300
+                effective_ttl = ttl_seconds if ttl_seconds is not None else (row[2] or 300)
+                if (datetime.now() - cached_time).total_seconds() < effective_ttl:
                     return row[0]
         return None
+
+    def clear_query_cache(
+        self,
+        cluster: Optional[str] = None,
+        database: Optional[str] = None,
+    ) -> int:
+        """Clear cached query results, optionally scoped to a cluster/database."""
+        clauses = []
+        params: List[str] = []
+
+        if cluster:
+            clauses.append("cluster = ?")
+            params.append(self.normalize_cluster_uri(cluster))
+        if database:
+            clauses.append("database = ?")
+            params.append(database)
+
+        delete_sql = "DELETE FROM query_cache"
+        if clauses:
+            delete_sql += " WHERE " + " AND ".join(clauses)
+
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(delete_sql, params)
+            removed = cursor.rowcount
+            conn.commit()
+        logger.info("Cleared %d cached query results", removed)
+        return removed
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """Get detailed cache statistics."""
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            total = conn.execute("SELECT COUNT(*) FROM query_cache").fetchone()[0]
+            by_type = {}
+            cursor = conn.execute(
+                "SELECT query_type, COUNT(*), AVG(row_count) FROM query_cache GROUP BY query_type"
+            )
+            for row in cursor:
+                by_type[row[0] or 'default'] = {"count": row[1], "avg_rows": round(row[2] or 0, 2)}
+            
+            # Count expired entries
+            expired = conn.execute("""
+                SELECT COUNT(*) FROM query_cache 
+                WHERE (julianday('now') - julianday(timestamp)) * 86400 > COALESCE(ttl_seconds, 300)
+            """).fetchone()[0]
+            
+            return {
+                "total_cached": total,
+                "expired_entries": expired,
+                "by_query_type": by_type
+            }
+
+    def cleanup_expired_cache(self) -> int:
+        """Remove expired cache entries and return count of removed entries."""
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("""
+                DELETE FROM query_cache 
+                WHERE (julianday('now') - julianday(timestamp)) * 86400 > COALESCE(ttl_seconds, 300)
+            """)
+            removed = cursor.rowcount
+            conn.commit()
+        logger.info("Removed %d expired cache entries", removed)
+        return removed
 
     def store_join_hint(self, table1: str, table2: str, condition: str):
         """Store a discovered join relationship."""
@@ -415,23 +895,25 @@ class MemoryManager:
         if not tables:
             return []
 
-        placeholders = ','.join(['?'] * len(tables))
         hints = []
+        if not tables:
+            return hints
 
+        placeholders = ','.join(['?'] * len(tables))
+        query = (
+            "SELECT table1, table2, join_condition FROM join_hints "
+            f"WHERE table1 IN ({placeholders}) OR table2 IN ({placeholders})"
+        )
         with self._lock, sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(f"""
-                SELECT table1, table2, join_condition FROM join_hints
-                WHERE table1 IN ({placeholders}) OR table2 IN ({placeholders})
-            """, tables + tables)
-
+            cursor = conn.execute(query, tables + tables)
             for row in cursor:
                 hints.append(f"{row[0]} joins with {row[1]} on {row[2]}")
-
         return list(set(hints))
 
     def _get_database_schema(self, cluster: str, database: str) -> List[Dict[str, Any]]:
         """Get schema from SQLite with caching."""
-        cache_key = f"db_schema_{cluster}_{database}"
+        normalized_cluster = self.normalize_cluster_uri(cluster)
+        cache_key = f"db_schema_{normalized_cluster}_{database}"
         # Simple in-memory cache check
         if hasattr(self, '_schema_cache') and cache_key in self._schema_cache:
             cached = self._schema_cache[cache_key]
@@ -441,7 +923,7 @@ class MemoryManager:
         with self._lock, sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
                 "SELECT table_name, columns_json FROM schemas WHERE cluster = ? AND database = ?",
-                (cluster, database)
+                (normalized_cluster, database)
             )
             schemas = [{"table": row[0], "columns": json.loads(row[1])} for row in cursor]
 
@@ -451,23 +933,26 @@ class MemoryManager:
         self._schema_cache[cache_key] = {'data': schemas, 'ts': datetime.now()}
         return schemas
 
-    def get_relevant_context(self, cluster: str, database: str, user_query: str, max_tables: int = 20) -> str:
+    def get_relevant_context(
+        self,
+        cluster: str,
+        database: str,
+        user_query: str,
+        max_tables: int = 20,
+        max_columns: int = 12
+    ) -> str:
         """
         Optimized CAG: Get schema + similar queries + join hints in TOON format.
         Limited to max_tables to prevent token overflow.
         """
-        # 1. Get schemas (limited)
-        schemas = self._get_database_schema(cluster, database)[:max_tables]
-        table_names = [s["table"] for s in schemas]
-
-        # 2. Get similar queries (parallel-safe)
-        similar_queries = self.find_similar_queries(cluster, database, user_query, limit=3)
-
-        # 3. Get join hints
-        join_hints = self.get_join_hints(table_names) if table_names else []
-
-        # 4. Format as compact TOON
-        return self._to_toon(schemas, similar_queries, join_hints)
+        bundle = self.build_cag_bundle(
+            cluster,
+            database,
+            user_query,
+            max_tables=max_tables,
+            max_columns=max_columns,
+        )
+        return bundle["context"]
 
     def _to_toon(self, schemas: List[Dict], similar_queries: List[Dict],
                  join_hints: Optional[List[str]] = None) -> str:
@@ -521,9 +1006,14 @@ class MemoryManager:
             with self._lock, sqlite3.connect(self.db_path) as conn:
                 conn.execute("DELETE FROM schemas")
                 conn.execute("DELETE FROM queries")
+                conn.execute("DELETE FROM query_cache")
+                conn.execute("DELETE FROM table_locations")
+                conn.execute("DELETE FROM join_hints")
                 conn.execute("DELETE FROM learning_events")
+            if hasattr(self, '_schema_cache'):
+                self._schema_cache.clear()
             return True
-        except Exception as e:
+        except (sqlite3.Error, OSError) as e:
             logger.error("Failed to clear memory: %s", e)
             return False
 
@@ -535,21 +1025,42 @@ class MemoryManager:
         return _normalize(uri) if uri else ""
 
     def get_memory_stats(self) -> Dict[str, Any]:
-        """Get statistics about the memory database."""
+        """Get statistics about the memory database including cache stats."""
         with self._lock, sqlite3.connect(self.db_path) as conn:
             schema_count = conn.execute("SELECT COUNT(*) FROM schemas").fetchone()[0]
             query_count = conn.execute("SELECT COUNT(*) FROM queries").fetchone()[0]
             learning_count = 0
+            learning_by_type: Dict[str, int] = {}
             try:
                 learning_count = conn.execute("SELECT COUNT(*) FROM learning_events").fetchone()[0]
+                cursor = conn.execute(
+                    "SELECT execution_type, COUNT(*) FROM learning_events GROUP BY execution_type"
+                )
+                learning_by_type = {row[0]: row[1] for row in cursor.fetchall() if row[0]}
             except sqlite3.OperationalError:
                 pass
+            
+            # Multi-cluster table count
+            multi_cluster_count = 0
+            try:
+                multi_cluster_count = conn.execute(
+                    "SELECT COUNT(DISTINCT table_name) FROM table_locations"
+                ).fetchone()[0]
+            except sqlite3.OperationalError:
+                pass
+            
             db_size = self.db_path.stat().st_size if self.db_path.exists() else 0
+
+        # Include cache stats
+        cache_stats = self.get_cache_stats()
 
         return {
             "schema_count": schema_count,
             "query_count": query_count,
             "learning_count": learning_count,
+            "learning_by_type": learning_by_type,
+            "multi_cluster_tables": multi_cluster_count,
+            "cache_stats": cache_stats,
             "db_size_bytes": db_size,
             "db_path": str(self.db_path)
         }
@@ -651,6 +1162,153 @@ class MemoryManager:
         """Compatibility method for legacy save_corpus calls (no-op)."""
         # This is intentionally empty for backwards compatibility
         return None
+
+    # ==================== Multi-Cluster Support Methods ====================
+
+    def register_table_location(
+        self, table_name: str, cluster: str, database: str
+    ) -> bool:
+        """
+        Register a table's location (cluster/database) for multi-cluster support.
+        
+        Args:
+            table_name: Name of the table
+            cluster: Cluster URL
+            database: Database name
+            
+        Returns:
+            True if registered successfully, False otherwise
+        """
+        try:
+            with self._lock, sqlite3.connect(self.db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO table_locations 
+                    (table_name, cluster, database, last_seen)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (table_name, cluster, database, datetime.now().isoformat())
+                )
+                conn.commit()
+            return True
+        except sqlite3.Error as e:
+            logging.error("Failed to register table location: %s", e)
+            return False
+
+    def get_table_locations(self, table_name: str) -> List[Dict[str, str]]:
+        """
+        Get all known locations (cluster/database pairs) for a table.
+        
+        Args:
+            table_name: Name of the table
+            
+        Returns:
+            List of dicts with 'cluster', 'database', 'last_seen' keys
+        """
+        try:
+            with self._lock, sqlite3.connect(self.db_path) as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT cluster, database, last_seen 
+                    FROM table_locations 
+                    WHERE table_name = ?
+                    ORDER BY last_seen DESC
+                    """,
+                    (table_name,)
+                )
+                return [
+                    {"cluster": row[0], "database": row[1], "last_seen": row[2]}
+                    for row in cursor.fetchall()
+                ]
+        except sqlite3.Error as e:
+            logging.error("Failed to get table locations: %s", e)
+            return []
+
+    def is_multi_cluster_table(self, table_name: str) -> bool:
+        """
+        Check if a table exists in multiple clusters.
+        
+        Args:
+            table_name: Name of the table
+            
+        Returns:
+            True if table is found in more than one cluster
+        """
+        try:
+            with self._lock, sqlite3.connect(self.db_path) as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT COUNT(DISTINCT cluster) 
+                    FROM table_locations 
+                    WHERE table_name = ?
+                    """,
+                    (table_name,)
+                )
+                count = cursor.fetchone()[0]
+                return count > 1
+        except sqlite3.Error as e:
+            logging.error("Failed to check multi-cluster status: %s", e)
+            return False
+
+    def get_all_table_locations(self) -> Dict[str, List[Dict[str, str]]]:
+        """
+        Get all registered tables and their locations.
+        
+        Returns:
+            Dict mapping table names to lists of location dicts
+        """
+        try:
+            with self._lock, sqlite3.connect(self.db_path) as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT table_name, cluster, database, last_seen 
+                    FROM table_locations 
+                    ORDER BY table_name, last_seen DESC
+                    """
+                )
+                result: Dict[str, List[Dict[str, str]]] = {}
+                for row in cursor.fetchall():
+                    table_name = row[0]
+                    if table_name not in result:
+                        result[table_name] = []
+                    result[table_name].append({
+                        "cluster": row[1],
+                        "database": row[2],
+                        "last_seen": row[3]
+                    })
+                return result
+        except sqlite3.Error as e:
+            logging.error("Failed to get all table locations: %s", e)
+            return {}
+
+    def remove_table_location(
+        self, table_name: str, cluster: str, database: str
+    ) -> bool:
+        """
+        Remove a specific table location entry.
+        
+        Args:
+            table_name: Name of the table
+            cluster: Cluster URL
+            database: Database name
+            
+        Returns:
+            True if removed successfully
+        """
+        try:
+            with self._lock, sqlite3.connect(self.db_path) as conn:
+                conn.execute(
+                    """
+                    DELETE FROM table_locations 
+                    WHERE table_name = ? AND cluster = ? AND database = ?
+                    """,
+                    (table_name, cluster, database)
+                )
+                conn.commit()
+            return True
+        except sqlite3.Error as e:
+            logging.error("Failed to remove table location: %s", e)
+            return False
 
 # Global instance
 _memory_manager = None

--- a/mcp_kql_server/performance.py
+++ b/mcp_kql_server/performance.py
@@ -9,7 +9,7 @@ This module provides:
 - Health monitoring for connections
 
 Author: Arjun Trivedi
-Version: 2.2.0
+Version: 2.1.1
 """
 
 import asyncio
@@ -155,6 +155,7 @@ class KustoConnectionPool:
         # Connection storage: cluster_url -> OrderedDict of ConnectionInfo
         self._pools: Dict[str, OrderedDict[str, ConnectionInfo]] = {}
         self._pool_locks: Dict[str, threading.Lock] = {}
+        self._health_check_databases: Dict[str, str] = {}
         self._global_lock = threading.RLock()
 
         # Statistics
@@ -263,6 +264,20 @@ class KustoConnectionPool:
 
             raise ConnectionError(f"Unable to get connection for {normalized_url}")
 
+    def register_health_check_database(self, cluster_url: str, database: str) -> None:
+        """Register a database that can be used for lightweight health probes."""
+        from .utils import normalize_cluster_uri
+
+        normalized_url = normalize_cluster_uri(cluster_url)
+        if not database:
+            return
+
+        with self._global_lock:
+            self._health_check_databases[normalized_url] = database
+
+        if not self._health_checker_running:
+            self.start_health_checker()
+
     def release_client(self, cluster_url: str) -> None:
         """
         Release a client back to the pool.
@@ -339,6 +354,7 @@ class KustoConnectionPool:
 
     def close_all(self) -> None:
         """Close all connections in the pool."""
+        self.stop_health_checker()  # Stop health checker before closing
         with self._global_lock:
             for cluster_url in list(self._pools.keys()):
                 pool_lock = self._get_pool_lock(cluster_url)
@@ -348,6 +364,128 @@ class KustoConnectionPool:
                         self._recycle_connection(cluster_url, conn_id)
             self._pools.clear()
         logger.info("[POOL] All connections closed")
+
+    # =========================================================================
+    # Health Check Scheduling
+    # =========================================================================
+
+    def start_health_checker(self) -> None:
+        """
+        Start the background health checker thread.
+        
+        The health checker periodically:
+        - Tests connection health using a lightweight query
+        - Marks unhealthy connections for recycling
+        - Cleans up idle and expired connections
+        """
+        if self._health_checker_running:
+            logger.warning("[POOL] Health checker already running")
+            return
+        
+        self._health_checker_running = True
+        self._health_checker_thread = threading.Thread(
+            target=self._health_checker_loop,
+            name="KustoPoolHealthChecker",
+            daemon=True
+        )
+        self._health_checker_thread.start()
+        logger.info(
+            "[POOL] Health checker started (interval=%ds)", 
+            self._health_check_interval
+        )
+
+    def stop_health_checker(self) -> None:
+        """Stop the background health checker thread."""
+        if not self._health_checker_running:
+            return
+        
+        self._health_checker_running = False
+        if self._health_checker_thread and self._health_checker_thread.is_alive():
+            # Wait for thread to finish (with timeout)
+            self._health_checker_thread.join(timeout=5.0)
+        self._health_checker_thread = None
+        logger.info("[POOL] Health checker stopped")
+
+    def _health_checker_loop(self) -> None:
+        """Background loop for periodic health checks."""
+        while self._health_checker_running:
+            try:
+                self._run_health_checks()
+                self.cleanup_idle_connections()
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                # Must catch all to keep health checker alive
+                logger.error("[POOL] Health check error: %s", e)
+            
+            # Sleep in small intervals to allow quick shutdown
+            for _ in range(self._health_check_interval):
+                if not self._health_checker_running:
+                    break
+                time.sleep(1)
+
+    def _run_health_checks(self) -> None:
+        """Run health checks on all pooled connections."""
+        checked = 0
+        unhealthy = 0
+        
+        with self._global_lock:
+            cluster_urls = list(self._pools.keys())
+        
+        for cluster_url in cluster_urls:
+            pool_lock = self._get_pool_lock(cluster_url)
+            with pool_lock:
+                pool = self._pools.get(cluster_url, {})
+                for conn_id, conn_info in list(pool.items()):
+                    checked += 1
+                    is_healthy = self._check_connection_health(conn_info)
+                    conn_info.is_healthy = is_healthy
+                    conn_info.last_health_check = datetime.now()
+                    
+                    if not is_healthy:
+                        unhealthy += 1
+                        logger.warning(
+                            "[POOL] Unhealthy connection detected: %s/%s",
+                            cluster_url, conn_id
+                        )
+                        # Recycle unhealthy connections
+                        self._recycle_connection(cluster_url, conn_id)
+        
+        if checked > 0:
+            logger.debug(
+                "[POOL] Health check complete: %d checked, %d unhealthy",
+                checked, unhealthy
+            )
+
+    def _check_connection_health(self, conn_info: ConnectionInfo) -> bool:
+        """
+        Check if a connection is healthy using a lightweight query.
+        
+        Args:
+            conn_info: Connection information
+            
+        Returns:
+            True if connection is healthy, False otherwise
+        """
+        try:
+            client = conn_info.client
+            if not hasattr(client, 'execute'):
+                return False
+
+            health_database = self._health_check_databases.get(conn_info.cluster_url)
+            if not health_database:
+                # No registered database for this cluster yet, so skip the probe
+                return True
+
+            # Use a very lightweight query to test connection against a known database
+            result = client.execute(health_database, "print 1")
+            return result is not None
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # Any error indicates unhealthy connection
+            logger.debug("[POOL] Health check failed: %s", e)
+            return False
+
+    def is_health_checker_running(self) -> bool:
+        """Check if the health checker is currently running."""
+        return self._health_checker_running
 
 
 # =============================================================================
@@ -546,15 +684,8 @@ class SchemaPreloader:
         total = len(tables)
         for idx, table in enumerate(tables):
             try:
-                # Use memory manager to cache schema
-                # store_schema expects schema dict, not individual columns/source args
-                memory.store_schema(
-                    cluster=cluster_url,
-                    database=database,
-                    table=table,
-                    schema={"columns": {}},  # Placeholder, will be discovered
-                    description="Preloaded at startup"
-                )
+                # Register presence only; do not overwrite an existing indexed schema.
+                memory.register_table_location(table, cluster_url, database)
                 results[table] = {"success": True, "preloaded": True}
 
                 if progress_callback:

--- a/mcp_kql_server/utils.py
+++ b/mcp_kql_server/utils.py
@@ -598,6 +598,23 @@ class SchemaManager:
         This function is now the single source of truth for live schema discovery.
         """
         try:
+            if not _force_refresh:
+                cached_schemas = self.memory_manager._get_database_schema(cluster, database)  # pylint: disable=protected-access
+                cached_schema = next((s for s in cached_schemas if s.get("table") == table), None)
+                if cached_schema and cached_schema.get("columns"):
+                    logger.debug("Using cached schema for %s.%s from schema memory", database, table)
+                    self.memory_manager.register_table_location(table, cluster, database)
+                    return {
+                        "table_name": table,
+                        "columns": cached_schema["columns"],
+                        "discovered_at": datetime.now().isoformat(),
+                        "cluster": cluster,
+                        "database": database,
+                        "column_count": len(cached_schema["columns"]),
+                        "discovery_method": "cached_schema_memory",
+                        "schema_version": "3.1",
+                    }
+
             logger.debug("Performing enhanced schema discovery for %s.%s", database, table)
 
             # Strategy 1: Try .show table schema as json (most detailed)
@@ -1153,13 +1170,11 @@ class SchemaManager:
                 "authentication_validated": validate_auth
             }
 
-            # Store each table schema
-            # Note: .show tables only gives names, not full schema.
-            # We store what we have (names) and let full discovery happen later if needed.
+            # Register discovered table locations without overwriting existing rich schemas.
             for table_name in table_list:
-                self.memory_manager.store_schema(cluster, database, table_name, {"columns": {}})
+                self.memory_manager.register_table_location(table_name, cluster, database)
 
-            logger.info("Stored newly discovered schema for database %s with %s tables", database, len(table_list))
+            logger.info("Registered %s discovered tables for database %s", len(table_list), database)
             return db_schema_obj
 
         except Exception as discovery_error:

--- a/mcp_kql_server/version_checker.py
+++ b/mcp_kql_server/version_checker.py
@@ -54,9 +54,11 @@ def fetch_latest_pypi_version(timeout: int = 5) -> Optional[str]:
             if response.status_code == 200:
                 data = response.json()
                 return data.get("info", {}).get("version")
-        except Exception as e:
+        except ImportError:
+            logger.debug("requests library not available for PyPI version check.")
+        except (OSError, ValueError, TypeError) as e:
             logger.debug("Failed to fetch PyPI version with requests: %s", e)
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.debug("Failed to fetch PyPI version: %s", e)
 
     return None
@@ -81,7 +83,7 @@ def compare_versions(current: str, latest: str) -> int:
             return 1
         else:
             return 0
-    except Exception:
+    except (TypeError, ValueError):
         # Fallback to string comparison
         if current < latest:
             return -1
@@ -153,7 +155,6 @@ def install_update() -> bool:
             timeout=120,
             check=False  # We handle the return code ourselves
         )
-
         if result.returncode == 0:
             logger.info("Update installed successfully")
             return True
@@ -187,7 +188,7 @@ def get_update_notification() -> Optional[str]:
                 f"|  Run: pip install --upgrade {PYPI_PACKAGE_NAME:<20}       |\n"
                 f"+---------------------------------------------------------------+\n"
             )
-    except Exception:
+    except (OSError, ValueError):
         pass
 
     return None
@@ -219,6 +220,6 @@ def startup_version_check(auto_update: bool = False, silent: bool = False) -> Tu
                 )
 
         return result["update_available"], result["message"]
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.debug("Version check failed: %s", e)
         return False, f"Version check failed: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-kql-server"
-version = "2.1.0"
+version = "2.1.1"
 description = "AI-Powered MCP server for KQL query execution with Natural Language to KQL (NL2KQL) conversion, intelligent schema memory, RAG-enhanced context assistance, and semantic search capabilities"
 authors = [{ name = "Arjun Trivedi", email = "arjuntrivedi42@yahoo.com" }]
 readme = "README.md"
@@ -33,24 +33,20 @@ classifiers = [
     "Topic :: Database :: Database Engines/Servers",
 ]
 dependencies = [
-    # Core framework dependencies
     "pydantic>=2.0.0,<3.0.0",
     "typing-extensions>=4.0.0,<5.0.0",
     "tabulate>=0.9.0,<1.0.0",
-    # MCP framework dependencies (essential)
-    "fastmcp>=2.0.0,<3.0.0",
-    # Azure dependencies for KQL/Kusto access (essential)
+    "fastmcp>=2.10.0,<3.0.0",
     "azure-kusto-data>=4.0.0,<6.0.0",
     "azure-identity>=1.15.0,<2.0.0",
-    # Networking and HTTP dependencies (essential)
+    "authlib>=1.3.0,<2.0.0",
+    "azure-core>=1.30.0,<2.0.0",
     "httpx>=0.25.0,<1.0.0",
     "requests>=2.31.0,<3.0.0",
     "tenacity>=8.0.0,<10.0.0",
-    # CLI and utility dependencies (essential)
     "click>=8.0.0,<9.0.0",
     "colorama>=0.4.6,<1.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
-    # AI/ML dependencies for enhanced RAG functionality
     "sentence-transformers>=2.0.0,<6.0.0",
     "scikit-learn>=1.0.0,<2.0.0",
     "numpy>=1.21.0,<3.0.0",
@@ -59,7 +55,16 @@ dependencies = [
     "pytest",
 ]
 
-# No optional dependencies needed for production
+[project.optional-dependencies]
+dev = [
+    "build>=1.2.0",
+    "pylint>=3.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=5.0.0",
+    "ruff>=0.9.0",
+    "toml>=0.10.2",
+    "twine>=5.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/4R9UN/mcp-kql-server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,12 @@ dependencies = [
     "scikit-learn>=1.0.0,<2.0.0",
     "numpy>=1.21.0,<3.0.0",
     "pandas",
-    "azure-cli",
-    "pytest",
 ]
 
 [project.optional-dependencies]
 dev = [
     "build>=1.2.0",
+    "pytest>=8.0.0",
     "pylint>=3.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pydantic>=2.0.0,<3.0.0
 typing-extensions>=4.0.0,<5.0.0
 
 # Azure Kusto (KQL) Integration
-azure-cli
 azure-kusto-data>=4.0.0,<6.0.0
 azure-identity>=1.15.0,<2.0.0
 authlib>=1.3.0,<2.0.0
@@ -28,9 +27,6 @@ tabulate>=0.9.0,<1.0.0
 python-dotenv>=1.0.0,<2.0.0
 click>=8.0.0,<9.0.0
 colorama>=0.4.6,<1.0.0
-
-
-pytest
 
 # -- Standard Libraries (included with Python, not installed via pip) --
 # pathlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # MCP KQL Server Dependencies
 
 # Core MCP Framework
-fastmcp>=2.0.0,<3.0.0
+fastmcp>=2.10.0,<3.0.0
 pydantic>=2.0.0,<3.0.0
 typing-extensions>=4.0.0,<5.0.0
 
@@ -9,6 +9,8 @@ typing-extensions>=4.0.0,<5.0.0
 azure-cli
 azure-kusto-data>=4.0.0,<6.0.0
 azure-identity>=1.15.0,<2.0.0
+authlib>=1.3.0,<2.0.0
+azure-core>=1.30.0,<2.0.0
 
 # Data Handling and AI/ML
 pandas
@@ -20,14 +22,14 @@ numpy>=1.21.0,<3.0.0
 httpx>=0.25.0,<1.0.0
 requests>=2.31.0,<3.0.0
 
-# Utilities
+
 tenacity>=8.0.0,<10.0.0
 tabulate>=0.9.0,<1.0.0
 python-dotenv>=1.0.0,<2.0.0
 click>=8.0.0,<9.0.0
 colorama>=0.4.6,<1.0.0
 
-# Testing
+
 pytest
 
 # -- Standard Libraries (included with Python, not installed via pip) --

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.4R9UN/mcp-kql-server",
   "title": "MCP KQL Server",
   "description": "Execute KQL in AI prompts via NL2KQL with schema discovery and Azure Data Explorer integration",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-kql-server",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,57 +5,29 @@ Author: Arjun Trivedi
 Email: arjuntrivedi42@yahoo.com
 """
 
+from mcp_kql_server.constants import (
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_QUERY_TIMEOUT,
+    LIMITS,
+    SERVER_NAME,
+    __version__,
+)
+
 
 def test_version_constants():
     """Test version constants are properly defined."""
-    try:
-        from mcp_kql_server.constants import __version__
-        # Version should match pyproject.toml (2.1.0)
-        assert __version__ == "2.1.0"
-    except ImportError:
-        pass
+    assert __version__ == "2.1.1"
 
 
 def test_server_constants():
     """Test server configuration constants."""
-    try:
-        from mcp_kql_server.constants import (
-            DEFAULT_CONNECTION_TIMEOUT,
-            DEFAULT_QUERY_TIMEOUT,
-            SERVER_NAME,
-            __version__,
-        )
-        # Dynamic check - SERVER_NAME should include current version
-        assert SERVER_NAME == f"mcp-kql-server({__version__})"
-        assert DEFAULT_CONNECTION_TIMEOUT > 0
-        assert DEFAULT_QUERY_TIMEOUT > 0
-    except ImportError:
-        pass
-
-
-def test_error_messages():
-    """Test error message constants."""
-    try:
-        from mcp_kql_server.constants import ERROR_MESSAGES
-
-        assert isinstance(ERROR_MESSAGES, dict)
-        assert "auth_failed" in ERROR_MESSAGES
-        assert "empty_query" in ERROR_MESSAGES
-
-    except ImportError:
-        # Skip test if module not available in CI
-        pass
+    assert SERVER_NAME == f"mcp-kql-server({__version__})"
+    assert DEFAULT_CONNECTION_TIMEOUT > 0
+    assert DEFAULT_QUERY_TIMEOUT > 0
 
 
 def test_limits():
     """Test limit constants."""
-    try:
-        from mcp_kql_server.constants import LIMITS
-
-        assert isinstance(LIMITS, dict)
-        assert "max_result_rows" in LIMITS
-        assert LIMITS["max_result_rows"] > 0
-
-    except ImportError:
-        # Skip test if module not available in CI
-        pass
+    assert isinstance(LIMITS, dict)
+    assert "max_result_rows" in LIMITS
+    assert LIMITS["max_result_rows"] > 0

--- a/tests/test_execute_kql.py
+++ b/tests/test_execute_kql.py
@@ -90,11 +90,10 @@ class TestExecuteKQL(unittest.TestCase):
         self.assertEqual(database, "your-database")
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_execute_kql_query_success(
-        self, mock_get_corpus, mock_connection_builder, mock_kusto_client, mock_get_memory  # pylint: disable=unused-argument
+        self, mock_get_corpus, mock_get_kusto_client, mock_get_memory
     ):
         """Test successful KQL query execution."""
         # Mock memory manager to disable caching
@@ -104,7 +103,7 @@ class TestExecuteKQL(unittest.TestCase):
 
         # Mock Kusto client
         mock_client_instance = MagicMock()
-        mock_kusto_client.return_value = mock_client_instance
+        mock_get_kusto_client.return_value = mock_client_instance
 
         # Mock query response
         mock_response = MagicMock()
@@ -135,11 +134,10 @@ class TestExecuteKQL(unittest.TestCase):
         self.assertEqual(result[0]["TestColumn"], "test_value")
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_execute_kql_query_with_visualization(
-        self, mock_get_corpus, mock_connection_builder, mock_kusto_client, mock_get_memory
+        self, mock_get_corpus, mock_get_kusto_client, mock_get_memory
     ):
         """Test KQL query execution with visualization."""
         # Mock memory manager to disable caching
@@ -149,7 +147,7 @@ class TestExecuteKQL(unittest.TestCase):
 
         # Mock Kusto client
         mock_client_instance = MagicMock()
-        mock_kusto_client.return_value = mock_client_instance
+        mock_get_kusto_client.return_value = mock_client_instance
 
         # Mock query response
         mock_response = MagicMock()
@@ -182,10 +180,9 @@ class TestExecuteKQL(unittest.TestCase):
         self.assertTrue(has_visualization)
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     def test_execute_kql_query_kusto_error(
-        self, mock_connection_builder, mock_kusto_client, mock_get_memory
+        self, mock_get_kusto_client, mock_get_memory
     ):
         """Test KQL query execution with Kusto service error."""
         # Mock memory manager to disable caching
@@ -195,7 +192,7 @@ class TestExecuteKQL(unittest.TestCase):
 
         # Mock Kusto client to raise error
         mock_client_instance = MagicMock()
-        mock_kusto_client.return_value = mock_client_instance
+        mock_get_kusto_client.return_value = mock_client_instance
         mock_client_instance.execute.side_effect = KustoServiceError("Test Kusto error")
 
         # Execute query and expect exception
@@ -203,11 +200,10 @@ class TestExecuteKQL(unittest.TestCase):
             asyncio.run(execute_kql_query(self.valid_query, use_schema_context=False))
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_execute_kql_query_with_schema_context(
-        self, mock_get_corpus, mock_connection_builder, mock_kusto_client, mock_get_memory
+        self, mock_get_corpus, mock_get_kusto_client, mock_get_memory
     ):
         """Test KQL query execution with schema context."""
         # Mock memory manager to disable caching
@@ -217,7 +213,7 @@ class TestExecuteKQL(unittest.TestCase):
 
         # Mock Kusto client
         mock_client_instance = MagicMock()
-        mock_kusto_client.return_value = mock_client_instance
+        mock_get_kusto_client.return_value = mock_client_instance
 
         # Mock query response
         mock_response = MagicMock()
@@ -253,11 +249,10 @@ class TestExecuteKQL(unittest.TestCase):
         self.assertIsInstance(result, list)
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_execute_kql_query_empty_results(
-        self, mock_get_corpus, mock_connection_builder, mock_kusto_client, mock_get_memory
+        self, mock_get_corpus, mock_get_kusto_client, mock_get_memory
     ):
         """Test KQL query execution with empty results."""
         # Mock memory manager to disable caching
@@ -267,7 +262,7 @@ class TestExecuteKQL(unittest.TestCase):
 
         # Mock Kusto client
         mock_client_instance = MagicMock()
-        mock_kusto_client.return_value = mock_client_instance
+        mock_get_kusto_client.return_value = mock_client_instance
 
         # Mock empty response
         mock_response = MagicMock()
@@ -292,15 +287,14 @@ class TestExecuteKQL(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(execute_kql_query(invalid_query, use_schema_context=False))
 
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_execute_kql_query_routes_management_commands(
-        self, mock_get_corpus, mock_conn_builder, mock_client_cls
+        self, mock_get_corpus, mock_get_kusto_client
     ):
         """Multi-statement script should route dot-commands to execute_mgmt."""
         mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        mock_get_kusto_client.return_value = mock_client
 
         # Data query primary result
         data_resp = MagicMock()
@@ -340,11 +334,10 @@ class TestExecuteKQL(unittest.TestCase):
         self.assertEqual(db, self.test_database)
 
     @patch("mcp_kql_server.execute_kql.get_memory_manager")
-    @patch("mcp_kql_server.execute_kql.KustoClient")
-    @patch("mcp_kql_server.execute_kql.KustoConnectionStringBuilder")
+    @patch("mcp_kql_server.execute_kql._get_kusto_client")
     @patch("mcp_kql_server.execute_kql.get_knowledge_corpus")
     def test_normalize_legacy_iplocation_to_geo_info(
-        self, mock_get_corpus, mock_conn_builder, mock_client_cls, mock_get_memory
+        self, mock_get_corpus, mock_get_kusto_client, mock_get_memory
     ):
         """Ensure iplocation() handling in queries."""
         # Mock memory manager to disable caching
@@ -353,7 +346,7 @@ class TestExecuteKQL(unittest.TestCase):
         mock_memory.get_cached_result.return_value = None
 
         mock_client = MagicMock()
-        mock_client_cls.return_value = mock_client
+        mock_get_kusto_client.return_value = mock_client
 
         # Mock response
         mock_response = MagicMock()

--- a/tests/test_generation_pipeline.py
+++ b/tests/test_generation_pipeline.py
@@ -1,0 +1,295 @@
+"""Focused tests for the CAG ranking and NL-to-KQL generation pipeline."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from mcp_kql_server.memory import MemoryManager
+from mcp_kql_server import mcp_server
+
+
+@pytest.fixture
+def memory_manager(tmp_path):
+    """Create an isolated memory manager for ranking tests."""
+    return MemoryManager(tmp_path / "ranking.db")
+
+
+def test_rank_tables_for_query_prefers_column_overlap(memory_manager):
+    """Hybrid ranking should prefer tables whose schema matches the request."""
+    memory_manager.store_schema(
+        "cluster",
+        "db",
+        "SigninLogs",
+        {
+            "TimeGenerated": {"data_type": "datetime"},
+            "UserPrincipalName": {"data_type": "string"},
+            "ResultType": {"data_type": "string"},
+            "IPAddress": {"data_type": "string"},
+        },
+    )
+    memory_manager.store_schema(
+        "cluster",
+        "db",
+        "DeviceInventory",
+        {
+            "DeviceId": {"data_type": "string"},
+            "DeviceName": {"data_type": "string"},
+            "OSPlatform": {"data_type": "string"},
+        },
+    )
+
+    ranked = memory_manager.rank_tables_for_query(
+        "cluster",
+        "db",
+        "show failed signins by user in the last 24 hours",
+        limit=2,
+    )
+
+    assert ranked
+    assert ranked[0]["table"] == "SigninLogs"
+    assert "UserPrincipalName" in ranked[0]["matched_columns"]
+
+
+def test_build_cag_bundle_fingerprints_columns(memory_manager):
+    """Compact CAG should keep only the highest-value columns."""
+    memory_manager.store_schema(
+        "cluster",
+        "db",
+        "SecurityAlert",
+        {
+            "TimeGenerated": {"data_type": "datetime"},
+            "AlertId": {"data_type": "string"},
+            "Severity": {"data_type": "string"},
+            "ProviderName": {"data_type": "string"},
+            "Description": {"data_type": "string"},
+            "ExtendedProperties": {"data_type": "dynamic"},
+        },
+    )
+
+    bundle = memory_manager.build_cag_bundle(
+        "cluster",
+        "db",
+        "count alerts by severity in the last 7 days",
+        max_tables=1,
+        max_columns=3,
+    )
+
+    assert bundle["tables"]
+    top_table = bundle["tables"][0]
+    assert len(top_table["selected_columns"]) <= 3
+    assert "Severity" in top_table["selected_columns"]
+    assert bundle["context"].startswith("<CAG_CONTEXT>")
+
+
+@pytest.mark.asyncio
+async def test_generate_kql_from_nl_uses_ranked_candidates():
+    """Generation should choose an aggregation candidate when the intent asks for counts."""
+    bundle = {
+        "tables": [
+            {
+                "table": "SecurityAlert",
+                "score": 9.0,
+                "matched_columns": ["Severity"],
+                "columns": {
+                    "TimeGenerated": {"data_type": "datetime"},
+                    "Severity": {"data_type": "string"},
+                    "AlertId": {"data_type": "string"},
+                },
+                "fingerprinted_columns": [
+                    {"name": "Severity", "data_type": "string", "score": 4.0},
+                    {"name": "TimeGenerated", "data_type": "datetime", "score": 3.0},
+                    {"name": "AlertId", "data_type": "string", "score": 1.0},
+                ],
+                "selected_columns": {
+                    "Severity": {"data_type": "string"},
+                    "TimeGenerated": {"data_type": "datetime"},
+                    "AlertId": {"data_type": "string"},
+                },
+            }
+        ],
+        "similar_queries": [],
+        "join_hints": [],
+        "context": "<CAG_CONTEXT>SecurityAlert(Severity:s, TimeGenerated:dt, AlertId:s)</CAG_CONTEXT>",
+    }
+
+    validator = AsyncMock(return_value={"valid": True, "errors": [], "columns_validated": 2})
+
+    with patch.object(mcp_server, "memory_manager", MagicMock()) as mocked_memory, \
+         patch.object(mcp_server, "kql_validator", MagicMock()) as mocked_validator:
+        mocked_memory.build_cag_bundle.return_value = bundle
+        mocked_validator.validate_query = validator
+
+        result = await mcp_server._generate_kql_from_natural_language(
+            "count alerts by severity in the last 24 hours",
+            "cluster",
+            "db",
+        )
+
+    assert result["success"] is True
+    assert result["generation_method"] == "cag_hybrid_ranking"
+    assert result["target_table"] == "SecurityAlert"
+    assert "summarize count_ = count() by Severity" in result["query_plain"]
+    assert result["query"] == result["query_plain"]
+
+
+@pytest.mark.asyncio
+async def test_generate_kql_from_nl_can_use_join_hints():
+    """Join-oriented requests should be able to use stored join hints."""
+    bundle = {
+        "tables": [
+            {
+                "table": "SecurityAlert",
+                "score": 9.0,
+                "matched_columns": ["DeviceId"],
+                "columns": {
+                    "TimeGenerated": {"data_type": "datetime"},
+                    "DeviceId": {"data_type": "string"},
+                    "AlertId": {"data_type": "string"},
+                },
+                "fingerprinted_columns": [
+                    {"name": "DeviceId", "data_type": "string", "score": 4.0},
+                    {"name": "TimeGenerated", "data_type": "datetime", "score": 3.0},
+                    {"name": "AlertId", "data_type": "string", "score": 1.0},
+                ],
+                "selected_columns": {
+                    "DeviceId": {"data_type": "string"},
+                    "TimeGenerated": {"data_type": "datetime"},
+                    "AlertId": {"data_type": "string"},
+                },
+            },
+            {
+                "table": "DeviceInventory",
+                "score": 8.0,
+                "matched_columns": ["DeviceId"],
+                "columns": {
+                    "DeviceId": {"data_type": "string"},
+                    "DeviceName": {"data_type": "string"},
+                    "OSPlatform": {"data_type": "string"},
+                },
+                "fingerprinted_columns": [
+                    {"name": "DeviceId", "data_type": "string", "score": 4.0},
+                    {"name": "DeviceName", "data_type": "string", "score": 3.0},
+                    {"name": "OSPlatform", "data_type": "string", "score": 2.0},
+                ],
+                "selected_columns": {
+                    "DeviceId": {"data_type": "string"},
+                    "DeviceName": {"data_type": "string"},
+                    "OSPlatform": {"data_type": "string"},
+                },
+            },
+        ],
+        "similar_queries": [],
+        "join_hints": ["SecurityAlert joins with DeviceInventory on DeviceId"],
+        "context": "<CAG_CONTEXT>join context</CAG_CONTEXT>",
+    }
+
+    validator = AsyncMock(return_value={"valid": True, "errors": [], "columns_validated": 3})
+
+    with patch.object(mcp_server, "memory_manager", MagicMock()) as mocked_memory, \
+         patch.object(mcp_server, "kql_validator", MagicMock()) as mocked_validator:
+        mocked_memory.build_cag_bundle.return_value = bundle
+        mocked_validator.validate_query = validator
+
+        result = await mcp_server._generate_kql_from_natural_language(
+            "join alerts with device inventory across device id",
+            "cluster",
+            "db",
+        )
+
+    assert result["success"] is True
+    assert "join kind=inner DeviceInventory on DeviceId" in result["query_plain"]
+
+
+@pytest.mark.asyncio
+async def test_execute_kql_query_repairs_invalid_time_column():
+    """Direct KQL with a wrong time column should be repaired from schema context before execution."""
+    validation_results = [
+        {
+            "valid": False,
+            "errors": [
+                "Column 'Timestamp' not found in table 'MtpAlertEvidence'. Sample columns: AlertId, ReportTime, DeviceId"
+            ],
+            "warnings": [],
+            "suggestions": ["Check column names against the schema"],
+            "tables_used": ["MtpAlertEvidence"],
+            "columns_validated": 1,
+        },
+        {
+            "valid": True,
+            "errors": [],
+            "warnings": [],
+            "suggestions": [],
+            "tables_used": ["MtpAlertEvidence"],
+            "columns_validated": 2,
+        },
+        {
+            "valid": True,
+            "errors": [],
+            "warnings": [],
+            "suggestions": [],
+            "tables_used": ["MtpAlertEvidence"],
+            "columns_validated": 2,
+        },
+    ]
+
+    with patch.object(mcp_server, "kusto_manager_global", {"authenticated": True}), \
+         patch.object(mcp_server, "kql_execute_tool", return_value=pd.DataFrame([{"AlertId": "a1", "ReportTime": "2026-01-01"}])), \
+         patch.object(mcp_server, "schema_manager", MagicMock()) as mocked_schema_manager, \
+         patch.object(mcp_server, "kql_validator", MagicMock()) as mocked_validator:
+        mocked_schema_manager.get_table_schema = AsyncMock(return_value={
+            "table_name": "MtpAlertEvidence",
+            "columns": {
+                "AlertId": {"data_type": "string"},
+                "ReportTime": {"data_type": "datetime"},
+                "DeviceId": {"data_type": "string"},
+            },
+        })
+        mocked_validator.validate_query = AsyncMock(side_effect=validation_results)
+
+        result = await mcp_server.execute_kql_query.fn(
+            query="MtpAlertEvidence | where AlertId == \"abc\" | order by Timestamp asc",
+            cluster_url="cluster",
+            database="db",
+            generate_query=False,
+        )
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["repair_applied"] is True
+    assert payload["replacements"]["Timestamp"] == "ReportTime"
+
+
+@pytest.mark.asyncio
+async def test_schema_get_context_can_be_scoped_to_table():
+    """Context retrieval should support a strict, single-table schema contract."""
+    with patch.object(mcp_server, "schema_manager", MagicMock()) as mocked_schema_manager, \
+         patch.object(mcp_server, "memory_manager", MagicMock()) as mocked_memory:
+        mocked_schema_manager.get_table_schema = AsyncMock(return_value={
+            "columns": {
+                "AlertId": {"data_type": "string"},
+                "ReportTime": {"data_type": "datetime"},
+                "DeviceId": {"data_type": "string"},
+            }
+        })
+        mocked_memory.find_similar_queries.return_value = []
+        mocked_memory.get_join_hints.return_value = []
+        mocked_memory.fingerprint_columns.return_value = [
+            {"name": "AlertId", "data_type": "string", "score": 2.0},
+            {"name": "ReportTime", "data_type": "datetime", "score": 1.0},
+        ]
+        mocked_memory._to_toon.return_value = "<CAG_CONTEXT>MtpAlertEvidence(AlertId:s, ReportTime:dt)</CAG_CONTEXT>"
+
+        result = await mcp_server._schema_get_context_operation(
+            "cluster",
+            "db",
+            "find alert evidence by alert id",
+            table_name="MtpAlertEvidence",
+        )
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["tables"] == ["MtpAlertEvidence"]
+    assert "AlertId" in payload["strict_schema"]["MtpAlertEvidence"]["allowed_columns"]
+    assert payload["strict_schema"]["MtpAlertEvidence"]["preferred_time_column"] == "ReportTime"

--- a/tests/test_kql_validator.py
+++ b/tests/test_kql_validator.py
@@ -1,0 +1,264 @@
+"""
+Tests for KQL Validator - Column and Table Extraction
+
+Tests the enhanced column extraction that validates columns in:
+- WHERE clause
+- PROJECT clause (simple and with aliases)
+- EXTEND clause (source columns)
+- SUMMARIZE BY clause
+- SORT/ORDER BY clause
+- TOP N BY clause
+- JOIN ON clause
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mcp_kql_server.kql_validator import KQLValidator
+
+
+@pytest.fixture
+def validator():
+    """Create a KQLValidator with mocked dependencies."""
+    mm = MagicMock()
+    sm = MagicMock()
+    val = KQLValidator(mm, sm)
+    val._ensure_schemas_exist = AsyncMock()
+    return val
+
+
+@pytest.fixture
+def mock_schema():
+    """Mock schema for CreateProcessEvents table."""
+    return {
+        "table": "CreateProcessEvents",
+        "columns": {
+            "TimeGenerated": "datetime",
+            "DeviceName": "string",
+            "ProcessName": "string",
+            "ProcessCommandLine": "string",
+            "AccountName": "string",
+            "InitiatingProcessName": "string",
+            "InitiatingProcessCommandLine": "string",
+            "ReportTime": "datetime",
+            "AlertId": "string",
+        }
+    }
+
+
+class TestTableExtraction:
+    """Tests for _extract_tables method."""
+    
+    def test_simple_table(self, validator):
+        """Test extracting simple table name."""
+        query = "CreateProcessEvents | where TimeGenerated > ago(1h)"
+        tables = validator._extract_tables(query)
+        assert "CreateProcessEvents" in tables
+    
+    def test_table_with_let_statement(self, validator):
+        """Test extracting table after let statement."""
+        query = """
+        let lookback = ago(1h);
+        CreateProcessEvents
+        | where TimeGenerated > lookback
+        """
+        tables = validator._extract_tables(query)
+        assert "CreateProcessEvents" in tables
+        assert "lookback" not in tables  # let variable should be excluded
+    
+    def test_cross_cluster_table(self, validator):
+        """Test extracting table from cross-cluster query."""
+        query = """
+        cluster('prod').database('security').CreateProcessEvents
+        | where TimeGenerated > ago(1h)
+        """
+        tables = validator._extract_tables(query)
+        assert "CreateProcessEvents" in tables
+    
+    def test_join_tables(self, validator):
+        """Test extracting tables from join query."""
+        query = """
+        CreateProcessEvents
+        | join kind=inner NetworkEvents on DeviceName
+        """
+        tables = validator._extract_tables(query)
+        assert "CreateProcessEvents" in tables or "NetworkEvents" in tables
+
+
+class TestColumnExtraction:
+    """Tests for _extract_column_references method."""
+    
+    def test_where_clause_columns(self, validator):
+        """Test extracting columns from WHERE clause."""
+        query = "CreateProcessEvents | where TimeGenerated > ago(1h) and DeviceName == 'test'"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TimeGenerated" in columns
+        assert "DeviceName" in columns
+    
+    def test_project_simple_columns(self, validator):
+        """Test extracting simple columns from PROJECT clause."""
+        query = "CreateProcessEvents | project TimeGenerated, DeviceName, ProcessName"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TimeGenerated" in columns
+        assert "DeviceName" in columns
+        assert "ProcessName" in columns
+    
+    def test_project_with_alias(self, validator):
+        """Test extracting source columns when PROJECT uses aliases."""
+        query = "CreateProcessEvents | project EventTime = TimeGenerated, Name = ProcessName"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TimeGenerated" in columns  # Source column should be extracted
+        assert "ProcessName" in columns  # Source column should be extracted
+        # Aliases should NOT be in the list (they're created, not read)
+    
+    def test_extend_source_columns(self, validator):
+        """Test extracting source columns from EXTEND clause."""
+        query = "CreateProcessEvents | extend NameLength = strlen(ProcessName)"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "ProcessName" in columns  # Source column in function
+    
+    def test_summarize_by_columns(self, validator):
+        """Test extracting columns from SUMMARIZE BY clause."""
+        query = "CreateProcessEvents | summarize count() by DeviceName, ProcessName"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "DeviceName" in columns
+        assert "ProcessName" in columns
+    
+    def test_top_by_column(self, validator):
+        """Test extracting column from TOP BY clause."""
+        query = "CreateProcessEvents | top 10 by TimeGenerated"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TimeGenerated" in columns
+
+
+class TestColumnValidation:
+    """Tests for full column validation against schema."""
+    
+    @pytest.mark.asyncio
+    async def test_valid_columns_pass(self, validator, mock_schema):
+        """Test that valid columns pass validation."""
+        validator.memory._get_database_schema.return_value = [mock_schema]
+        
+        query = """
+        CreateProcessEvents
+        | where TimeGenerated > ago(1h)
+        | project DeviceName, ProcessName
+        """
+        
+        result = await validator.validate_query(
+            query, "cluster", "db", auto_discover=False
+        )
+        
+        assert result["valid"]
+        assert len(result["errors"]) == 0
+    
+    @pytest.mark.asyncio
+    async def test_invalid_column_in_project_fails(self, validator, mock_schema):
+        """Test that invalid column in PROJECT clause fails validation."""
+        validator.memory._get_database_schema.return_value = [mock_schema]
+        
+        # EventTime and Title don't exist in the schema
+        query = """
+        CreateProcessEvents
+        | where TimeGenerated > ago(1h)
+        | project EventTime, Title, ProcessName
+        """
+        
+        result = await validator.validate_query(
+            query, "cluster", "db", auto_discover=False
+        )
+        
+        assert not result["valid"]
+        assert any("EventTime" in err for err in result["errors"])
+        assert any("Title" in err for err in result["errors"])
+    
+    @pytest.mark.asyncio
+    async def test_invalid_column_in_where_fails(self, validator, mock_schema):
+        """Test that invalid column in WHERE clause fails validation."""
+        validator.memory._get_database_schema.return_value = [mock_schema]
+        
+        query = """
+        CreateProcessEvents
+        | where EventTime > ago(1h)
+        """
+        
+        result = await validator.validate_query(
+            query, "cluster", "db", auto_discover=False
+        )
+        
+        assert not result["valid"]
+        assert any("EventTime" in err for err in result["errors"])
+
+
+class TestFuzzyMatching:
+    """Tests for fuzzy column name suggestions."""
+    
+    def test_similar_column_suggestions(self, validator):
+        """Test that similar column names are suggested."""
+        valid_columns = ["TimeGenerated", "ProcessName", "DeviceName", "AccountName"]
+        
+        # Test typo in column name
+        suggestions = validator._find_similar_columns("ProcessNam", valid_columns)
+        assert "ProcessName" in suggestions
+        
+        # Test partial match
+        suggestions = validator._find_similar_columns("TimGenerated", valid_columns)
+        assert "TimeGenerated" in suggestions
+    
+    def test_no_suggestions_for_completely_different(self, validator):
+        """Test that no suggestions for completely different names."""
+        valid_columns = ["TimeGenerated", "ProcessName", "DeviceName"]
+        
+        suggestions = validator._find_similar_columns("XyzAbcDef", valid_columns)
+        assert len(suggestions) == 0
+
+
+class TestProjectAway:
+    """Tests for project-away and project-keep extraction."""
+    
+    def test_project_away_columns(self, validator):
+        """Test extracting columns from project-away clause."""
+        query = "CreateProcessEvents | project-away TimeGenerated, DeviceName"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TimeGenerated" in columns
+        assert "DeviceName" in columns
+    
+    def test_project_keep_columns(self, validator):
+        """Test extracting columns from project-keep clause."""
+        query = "CreateProcessEvents | project-keep ProcessName, AccountName"
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "ProcessName" in columns
+        assert "AccountName" in columns
+
+
+class TestCreatedAliases:
+    """Tests for _extract_created_aliases method."""
+    
+    def test_summarize_aliases_excluded(self, validator):
+        """Test that summarize aliases are not validated as table columns."""
+        query = "CreateProcessEvents | summarize TotalEvents = count() by DeviceName"
+        aliases = validator._extract_created_aliases(query)
+        assert "TotalEvents" in aliases
+        
+        # The alias should NOT appear in column references to validate
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "TotalEvents" not in columns
+        assert "DeviceName" in columns  # This is a real column
+    
+    def test_extend_aliases_excluded(self, validator):
+        """Test that extend aliases are not validated as table columns."""
+        query = "CreateProcessEvents | extend ProcessLength = strlen(ProcessName)"
+        aliases = validator._extract_created_aliases(query)
+        assert "ProcessLength" in aliases
+        
+        columns = validator._extract_column_references(query, "CreateProcessEvents")
+        assert "ProcessLength" not in columns
+        assert "ProcessName" in columns  # Source column should be validated
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -5,40 +5,30 @@ Author: Arjun Trivedi
 Email: arjuntrivedi42@yahoo.com
 """
 
+import mcp_kql_server
+
+from mcp_kql_server import __author__, __email__, __version__ as pkg_version
+from mcp_kql_server.constants import __version__ as const_version
+from mcp_kql_server.utils import bracket_if_needed, normalize_cluster_uri, sanitize_filename
+
 
 def test_package_imports():
     """Test that package imports work correctly."""
-    try:
-        import mcp_kql_server
-        assert hasattr(mcp_kql_server, "__version__")
-        assert hasattr(mcp_kql_server, "__author__")
-        assert mcp_kql_server.__version__ == "2.1.0"
-        assert mcp_kql_server.__author__ == "Arjun Trivedi"
-    except ImportError:
-        pass
+    assert hasattr(mcp_kql_server, "__version__")
+    assert hasattr(mcp_kql_server, "__author__")
+    assert mcp_kql_server.__version__ == "2.1.1"
+    assert mcp_kql_server.__author__ == "Arjun Trivedi"
 
 
 def test_version_consistency():
     """Test that version is consistent across modules."""
-    try:
-        from mcp_kql_server import __version__ as pkg_version
-        from mcp_kql_server.constants import __version__ as const_version
-        # Both should match - 2.1.0
-        assert pkg_version == const_version == "2.1.0"
-    except ImportError:
-        pass
+    assert pkg_version == const_version == "2.1.1"
 
 
 def test_author_attribution():
     """Test that author information is properly set."""
-    try:
-        from mcp_kql_server import __author__, __email__
-
-        assert __author__ == "Arjun Trivedi"
-        assert __email__ == "arjuntrivedi42@yahoo.com"
-    except ImportError:
-        # Skip test if package not available in CI
-        pass
+    assert __author__ == "Arjun Trivedi"
+    assert __email__ == "arjuntrivedi42@yahoo.com"
 
 
 def test_module_structure():
@@ -61,14 +51,6 @@ def test_module_structure():
 
 def test_basic_functionality():
     """Test basic package functionality without external dependencies."""
-    try:
-        # Test that we can import key functions
-        from mcp_kql_server.utils import is_debug_mode, truncate_string
-
-        # Test basic utility functions
-        assert truncate_string("Hello World", 5) == "He..."
-        assert isinstance(is_debug_mode(), bool)
-
-    except ImportError:
-        # Skip test if modules not available
-        pass
+    assert sanitize_filename("bad:file/name?.txt") == "bad_file_name_.txt"
+    assert normalize_cluster_uri("help.kusto.windows.net") == "https://help.kusto.windows.net"
+    assert bracket_if_needed("where") == "['where']"

--- a/tests/test_runtime_improvements.py
+++ b/tests/test_runtime_improvements.py
@@ -1,0 +1,144 @@
+"""Regression tests for cache scoping, table tracking, and runtime safety."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_kql_server.memory import MemoryManager
+from mcp_kql_server.performance import ConnectionInfo, KustoConnectionPool
+from mcp_kql_server.utils import SchemaManager
+
+
+@pytest.fixture
+def memory_manager(tmp_path):
+    """Create an isolated memory manager."""
+    return MemoryManager(tmp_path / "runtime.db")
+
+
+def test_cache_isolated_by_cluster_and_namespace(memory_manager):
+    """The same query text should not collide across clusters or cache namespaces."""
+    query = "SecurityAlert | take 1"
+    memory_manager.cache_query_result(
+        query,
+        json.dumps({"source": "cluster-a-json"}),
+        1,
+        cluster="https://cluster-a.kusto.windows.net",
+        database="db",
+        cache_namespace="execute:json",
+    )
+    memory_manager.cache_query_result(
+        query,
+        json.dumps({"source": "cluster-b-table"}),
+        1,
+        cluster="https://cluster-b.kusto.windows.net",
+        database="db",
+        cache_namespace="execute:table",
+    )
+
+    cached_a = memory_manager.get_cached_result(
+        query,
+        cluster="https://cluster-a.kusto.windows.net",
+        database="db",
+        cache_namespace="execute:json",
+    )
+    cached_b = memory_manager.get_cached_result(
+        query,
+        cluster="https://cluster-b.kusto.windows.net",
+        database="db",
+        cache_namespace="execute:table",
+    )
+
+    assert json.loads(cached_a)["source"] == "cluster-a-json"
+    assert json.loads(cached_b)["source"] == "cluster-b-table"
+
+
+def test_store_schema_registers_persistent_table_locations(memory_manager):
+    """Schema storage should also populate the persistent table location registry."""
+    schema = {"columns": {"TimeGenerated": {"data_type": "datetime"}}}
+    memory_manager.store_schema("https://cluster-a.kusto.windows.net", "db", "SecurityAlert", schema)
+    memory_manager.store_schema("https://cluster-b.kusto.windows.net", "db", "SecurityAlert", schema)
+
+    locations = memory_manager.get_table_locations("SecurityAlert")
+
+    assert len(locations) == 2
+    assert {item["cluster"] for item in locations} == {
+        "https://cluster-a.kusto.windows.net",
+        "https://cluster-b.kusto.windows.net",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cached_schema_is_reused_without_reindex(memory_manager):
+    """If a real schema already exists, schema retrieval should use it without live re-discovery."""
+    memory_manager.store_schema(
+        "https://cluster-a.kusto.windows.net",
+        "db",
+        "SecurityAlert",
+        {"columns": {"AlertId": {"data_type": "string"}, "ReportTime": {"data_type": "datetime"}}},
+    )
+    manager = SchemaManager(memory_manager)
+    manager._execute_kusto_async = AsyncMock(side_effect=AssertionError("live discovery should not run"))
+
+    schema = await manager.get_table_schema("https://cluster-a.kusto.windows.net", "db", "SecurityAlert")
+
+    assert schema["discovery_method"] == "cached_schema_memory"
+    assert "AlertId" in schema["columns"]
+
+
+def test_clear_query_cache_can_be_scoped(memory_manager):
+    """Scoped cache clear should only remove matching entries."""
+    query = "SecurityAlert | take 1"
+    memory_manager.cache_query_result(query, "a", 1, cluster="https://cluster-a.kusto.windows.net", database="db")
+    memory_manager.cache_query_result(query, "b", 1, cluster="https://cluster-b.kusto.windows.net", database="db")
+
+    removed = memory_manager.clear_query_cache(cluster="https://cluster-a.kusto.windows.net", database="db")
+
+    assert removed == 1
+    assert memory_manager.get_cached_result(
+        query,
+        cluster="https://cluster-a.kusto.windows.net",
+        database="db",
+    ) is None
+    assert memory_manager.get_cached_result(
+        query,
+        cluster="https://cluster-b.kusto.windows.net",
+        database="db",
+    ) == "b"
+
+
+def test_memory_stats_include_generation_telemetry(memory_manager):
+    """Generation events should be visible in memory stats."""
+    memory_manager.store_learning_result(
+        "count alerts by severity",
+        {"query": "SecurityAlert | summarize count() by Severity"},
+        execution_type="generation",
+    )
+
+    stats = memory_manager.get_memory_stats()
+
+    assert stats["learning_by_type"]["generation"] == 1
+
+
+def test_health_checker_uses_registered_database():
+    """Health checks should probe a registered database, not the cluster URL."""
+    pool = KustoConnectionPool()
+    pool._health_check_databases.clear()  # pylint: disable=protected-access
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, database, query):
+            self.calls.append((database, query))
+            return {"ok": True}
+
+    client = FakeClient()
+    conn_info = ConnectionInfo(client=client, cluster_url="https://cluster.kusto.windows.net")
+    pool.register_health_check_database("https://cluster.kusto.windows.net", "SecurityDB")
+
+    try:
+        assert pool._check_connection_health(conn_info) is True  # pylint: disable=protected-access
+        assert client.calls == [("SecurityDB", "print 1")]
+    finally:
+        pool.stop_health_checker()


### PR DESCRIPTION
## Summary

This PR finalizes the `2.1.1` branch state by aligning the shipped docs, examples, packaging metadata, runtime behavior, and CI validation with the actual repository implementation.

### What changed

- aligned package metadata, server manifest, and release docs to `2.1.1`
- updated docs and examples to the current MCP tool contract:
  - `execute_kql_query`
  - `schema_memory`
- preserved the local Azure CLI auth flow (`az login`) while clarifying Azure-hosted managed identity guidance in docs
- updated the production Docker build to install from `pyproject.toml` / built wheel and run `python -m mcp_kql_server`
- removed stale API and troubleshooting references that no longer matched runtime behavior
- removed `tf-keras` from `requirements.txt` because it is not a direct dependency of the current codepath

### Runtime improvements included in this branch

- added schema-grounded NL2KQL ranking and compact CAG retrieval
- added strict table-scoped schema context for `schema_memory(operation="get_context")`
- added schema-backed repair for invalid direct-query columns before execution
- scoped query-result caching by query, cluster, database, and namespace
- added multi-cluster table tracking and cache statistics / cleanup operations
- reused cached schemas before live discovery and avoided overwriting rich schemas with placeholders
- switched execution paths to the shared connection pool and added health-check database registration
- tightened subprocess and version-checker error handling paths

### Test and CI updates

- added regression coverage for:
  - generation pipeline ranking
  - runtime cache scoping and schema reuse
  - validator table/column extraction
- updated tests to reflect pooled client behavior and current public helpers
- fixed GitHub Actions so `test-and-coverage` now actually runs pytest with coverage and uploads `coverage.xml`

## Validation

Validated locally before opening this PR:

- `ruff check .`
- `python -m pytest -q` → `89 passed, 1 skipped`
- `python -m build`
- `python -m twine check dist/*`
- `python -m pip install .`
- import verification for `mcp_kql_server`
- `python -m pytest --cov=mcp_kql_server --cov-report=term-missing --cov-report=xml -q`

## Notes

- version remains `2.1.1` as requested
- local/main auth flow remains Azure CLI based
- CI is now more honest: it enforces tests instead of only installing the package
- pytest coverage runs currently surface non-blocking SQLite `ResourceWarning` messages; these do not fail the workflow but are a good follow-up cleanup item
