### PR TITLE
fix: improve FastMCP startup and HTTP transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,18 @@ jobs:
         echo "Checking version consistency"
         PYPROJECT_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
         echo "pyproject.toml version: $PYPROJECT_VERSION"
-        INIT_VERSION=$(grep -E '^__version__\s*=' mcp_kql_server/__init__.py | sed 's/.*=\s*["'"'"'"]\([^"'"'"']*\)["'"'"'"].*/\1/')
-        echo "__init__.py version: $INIT_VERSION"
-        if [ "$PYPROJECT_VERSION" = "$INIT_VERSION" ]; then
+        # constants.py holds the literal single source of truth; __init__.py re-exports it.
+        CONST_VERSION=$(grep -E '^__version__\s*=' mcp_kql_server/constants.py | sed 's/.*=\s*["'"'"'"]\([^"'"'"']*\)["'"'"'"].*/\1/')
+        echo "constants.py version: $CONST_VERSION"
+        SERVER_JSON_VERSION=$(python -c "import json; print(json.load(open('server.json'))['version'])")
+        echo "server.json version: $SERVER_JSON_VERSION"
+        if [ "$PYPROJECT_VERSION" = "$CONST_VERSION" ] && [ "$PYPROJECT_VERSION" = "$SERVER_JSON_VERSION" ]; then
           echo "All versions are consistent: $PYPROJECT_VERSION"
         else
           echo "Version mismatch detected!"
           echo "pyproject.toml: $PYPROJECT_VERSION"
-          echo "__init__.py: $INIT_VERSION"
+          echo "constants.py: $CONST_VERSION"
+          echo "server.json: $SERVER_JSON_VERSION"
           exit 1
         fi
         if [[ "${GITHUB_REF}" == refs/tags/* ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -342,4 +342,17 @@ RELEASE_NOTES_v2.0.3.md
 mcp-publisher.exe
 .mcpregistry_github_token
 .mcpregistry_registry_token
-.gitignore
+
+# Graphify local artifacts and assistant configuration
+graphify-out/
+.graphify/
+.graphify_*
+.github/copilot-instructions.md
+AGENTS.md
+CLAUDE.md
+.claude/
+.codex/
+.gemini/
+.kiro/
+.agent/
+.cursor/rules/graphify.mdc

--- a/Example/mcp_kql_usage_examples.py
+++ b/Example/mcp_kql_usage_examples.py
@@ -105,10 +105,10 @@ def example_performance_optimized() -> Dict[str, Any]:
 
 
 def example_schema_memory() -> Dict[str, Any]:
-    """Discover schema using the current schema_memory tool."""
+    """Discover schema using the current kql_schema_memory tool."""
 
     request = {
-        "tool": "schema_memory",
+        "tool": "kql_schema_memory",
         "input": {
             "operation": "discover",
             "cluster_url": "https://project-cluster.kusto.windows.net",
@@ -166,7 +166,7 @@ def usage_patterns():
     patterns = {
         "workflow_2_development": [
             "1. Run az login before starting the server locally",
-            "2. Use schema_memory(discover/list_tables/get_context) before NL2KQL-heavy sessions",
+            "2. Use kql_schema_memory(discover/list_tables/get_context) before NL2KQL-heavy sessions",
             "3. Prefer table or JSON output depending on how your MCP client renders results",
         ],
         "workflow_3_performance": [
@@ -177,8 +177,8 @@ def usage_patterns():
         "best_practices": [
             "Always authenticate with Azure CLI first (az login)",
             "Use specific time ranges to limit query scope",
-            "Use schema_memory(refresh_schema) when table metadata changes",
-            "Use schema_memory(get_context) to ground NL2KQL with the right tables",
+            "Use kql_schema_memory(refresh_schema) when table metadata changes",
+            "Use kql_schema_memory(get_context) to ground NL2KQL with the right tables",
             "Keep local Azure CLI auth and Azure-hosted managed identity flows documented separately",
         ],
     }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mcp-name: io.github.4R9UN/mcp-kql-server
 
 A Model Context Protocol (MCP) server that transforms natural language questions into optimized KQL queries with intelligent schema discovery, AI-powered caching, and seamless Azure Data Explorer integration. Simply ask questions in plain English and get instant, accurate KQL queries with context-aware results.
 
-**Latest Version: v2.1.2** - Hardcoded 10-minute Kusto `servertimeout`, ADX-side dry-run validation for generated queries, schema-drift recovery loop, and fully schema-driven NL2KQL with no hardcoded table or column names.
+**Latest Version: v2.1.3** - FastMCP v2 and v3 compatibility range, faster MCP startup, deferred Azure CLI auth, optional update checks, shared streamable HTTP transport, and SQLite concurrency hardening for multiple local MCP instances.
 
 <!-- Badges Section -->
 
@@ -35,25 +35,6 @@ Watch a quick demo of the MCP KQL Server in action:
 
 [![MCP KQL Server Demo](https://img.youtube.com/vi/Ca-yuThJ3Vc/0.jpg)](https://www.youtube.com/watch?v=Ca-yuThJ3Vc)
 
-## 🆕 What's New in v2.1.2
-
-- **⏱️ Hardcoded 10-min Query Timeout**: Every Kusto call now ships `ClientRequestProperties.servertimeout` (capped at 600s). Long queries no longer silently die at the ADX default of ~4 minutes.
-- **🔍 ADX-Side Dry-Run Validation**: NL2KQL leader candidates are wrapped as `<query> | take 0` and bound by ADX itself. Catches schema drift the cached validator misses, costs zero rows.
-- **🔁 Schema-Drift Recovery Loop**: On `SEM0100` / "failed to resolve" failures the server refreshes the schema, repairs the query against real columns, and retries exactly once. No infinite loops.
-- **🧭 Smarter Retry Policy**: Server-side timeouts are no longer auto-retried (was burning 3× the budget). Only true transport failures (refused, reset, throttled, DNS, socket) retry.
-- **🪪 Per-Request Trace IDs**: Each Kusto call carries a unique `client_request_id` for cross-process correlation.
-- **🧹 Schema-Driven Generation**: Removed all hardcoded table, cluster, and column names from the NL2KQL pipeline. Time columns and join keys are derived from the live schema.
-- **🧰 Cleanup**: Removed legacy manual verification scripts; added pinned regression tests for timeout, error classifier, and dry-run.
-
-## 🆕 What's New in v2.1.1
-
-- **🎯 Schema-First CAG**: KQL generation now ranks tables and columns from cached schema context before building queries.
-- **🧠 Strict Table Context**: `schema_memory(operation="get_context")` can be scoped to a specific table and returns allowed/recommended columns.
-- **🩹 Schema-Grounded Repair**: Invalid client-generated KQL can be repaired against real schema columns before execution.
-- **💾 Safer Cache Isolation**: Query-result cache is scoped by query, cluster, database, and output namespace.
-- **♻️ No Redundant Reindexing**: Existing cached schemas are reused and no longer overwritten by placeholder discovery paths.
-
-See [RELEASE_NOTES.md](RELEASE_NOTES.md) for full details.
 
 ## 🚀 Features
 
@@ -64,7 +45,7 @@ See [RELEASE_NOTES.md](RELEASE_NOTES.md) for full details.
     - **Strict Schema Validation**: Uses discovered schema memory and validation before execution.
     - **Schema-Grounded Repair**: Repairs invalid columns only when a valid table schema can prove the replacement.
 
-- **`schema_memory`**:
+- **`kql_schema_memory`**:
     - **Schema Discovery**: Discover and cache schemas for tables.
     - **Database Exploration**: List all tables within a database.
     - **AI Context**: Get ranked CAG context for tables, with optional table-scoped strict schema output.
@@ -195,7 +176,7 @@ Add to your Claude Desktop MCP settings file (`mcp_settings.json`):
 ```json
 {
   "mcpServers": {
-    "mcp-kql-server": {
+    "mcpKqlServer": {
       "type": "stdio",
       "command": "python",
       "args": ["-m", "mcp_kql_server"]
@@ -207,11 +188,11 @@ Add to your Claude Desktop MCP settings file (`mcp_settings.json`):
 <details>
 <summary>Alternatives: platform-stable launchers or the installed console script</summary>
 
-Windows (the `py` launcher always lives at `C:\Windows\py.exe`):
+Windows (the `py` launcher is commonly available as `py`; use `Get-Command py` if you need its full path):
 ```json
 {
   "mcpServers": {
-    "mcp-kql-server": {
+    "mcpKqlServer": {
       "type": "stdio",
       "command": "py",
       "args": ["-3", "-m", "mcp_kql_server"]
@@ -221,18 +202,6 @@ Windows (the `py` launcher always lives at `C:\Windows\py.exe`):
 ```
 On macOS / Linux replace `"py"` with `"python3"` and drop the `"-3"` arg.
 
-Or use the console script that `pip install` drops on `PATH`:
-```json
-{
-  "mcpServers": {
-    "mcp-kql-server": {
-      "type": "stdio",
-      "command": "mcp-kql-server",
-      "args": []
-    }
-  }
-}
-```
 </details>
 
 ### VSCode (with MCP Extension)
@@ -247,16 +216,69 @@ Add to your VSCode MCP configuration:
 ```json
 {
   "servers": {
-    "mcp-kql-server": {
+    "mcpKqlServer": {
       "type": "stdio",
-      "command": "python",
-      "args": ["-m", "mcp_kql_server"]
+      "command": "py",
+      "args": ["-3", "-m", "mcp_kql_server", "--transport", "stdio"],
+      "timeout": 300000,
+      "env": {
+        "FASTMCP_TRANSPORT": "stdio",
+        "MCP_KQL_AUTH_ON_STARTUP": "false",
+        "MCP_KQL_CHECK_FOR_UPDATES": "false",
+        "MCP_KQL_DEFER_AUTH": "1",
+        "MCP_KQL_SKIP_STARTUP_VERSION_CHECK": "1",
+        "MCP_KQL_AUTH_CHECK_TIMEOUT_SECONDS": "10",
+        "MCP_KQL_AUTH_LOGIN_TIMEOUT_SECONDS": "120",
+        "MCP_KQL_SQLITE_BUSY_TIMEOUT_MS": "30000"
+      }
     }
   }
 }
 ```
 
 > **If VS Code logs `spawn ...PythonNNN/python.exe ENOENT`**, the Python extension is substituting a cached interpreter path for `"python"`. Switch to `"py"` (Windows) / `"python3"` (macOS/Linux), or to the `"mcp-kql-server"` console script that `pip install` drops on `PATH`. See [docs/troubleshooting.md](docs/troubleshooting.md#8-mcp-integration-issues) for full details.
+
+> **Windows tip**: use `py -3 -m mcp_kql_server` so VS Code does not need a user-specific Python path. If you must use a full path locally, keep it in your private `mcp.json`, not in shared documentation.
+
+> **If the server starts but VS Code still shows no tools**, run `MCP: Reset Cached Tools`, then `MCP: Reset Trust`, and restart the server from `MCP: List Servers`. VS Code stores trust and cached tools separately from `mcp.json`, so a previous failed launch can keep the old empty state until you reset it.
+
+### Shared HTTP Mode for Multiple MCP Clients
+
+Use shared HTTP when VS Code, GitHub Copilot CLI, agents, or other MCP clients should connect to one persistent MCP KQL server process.
+
+Start the server:
+
+```bash
+python -m mcp_kql_server --transport http --host 127.0.0.1 --port 8000 --http-path /mcp --stateless-http
+```
+
+Client configuration:
+
+```json
+{
+  "servers": {
+    "mcpKqlServer": {
+      "type": "http",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
+
+### Runtime Settings Added in v2.1.3
+
+| Option or environment variable | Purpose | Default |
+| --- | --- | --- |
+| `--transport`, `FASTMCP_TRANSPORT` | `stdio`, `http`, `streamable-http`, or `sse` | `stdio` |
+| `--host`, `FASTMCP_HOST` | HTTP bind host | `127.0.0.1` |
+| `--port`, `FASTMCP_PORT` | HTTP bind port | `8000` |
+| `--http-path`, `FASTMCP_STREAMABLE_HTTP_PATH` | Streamable HTTP endpoint path | `/mcp` |
+| `--stateless-http`, `FASTMCP_STATELESS_HTTP` | Stateless HTTP mode for shared deployments | `false` |
+| `--auth-on-startup`, `MCP_KQL_AUTH_ON_STARTUP` | Check Azure CLI auth before startup | `false` |
+| `--check-updates`, `MCP_KQL_CHECK_FOR_UPDATES` | Check PyPI for package updates before startup | `false` |
+| `MCP_KQL_AUTH_CHECK_TIMEOUT_SECONDS` | Azure CLI auth check timeout | `10` |
+| `MCP_KQL_AUTH_LOGIN_TIMEOUT_SECONDS` | Interactive Azure login timeout | `120` |
+| `MCP_KQL_SQLITE_BUSY_TIMEOUT_MS` | SQLite busy timeout for concurrent local MCP instances | `30000` |
 
 ### Roo-code Or Cline (VS-code Extentions)
 
@@ -291,9 +313,12 @@ python3 -m mcp_kql_server   # macOS / Linux
 # Equivalent console script installed by pip
 mcp-kql-server
 
+# Shared HTTP mode for multiple clients
+python -m mcp_kql_server --transport http --host 127.0.0.1 --port 8000 --http-path /mcp --stateless-http
+
 # Server provides these tools:
 # - execute_kql_query: Execute KQL or generate KQL from natural language
-# - schema_memory: Discover, cache, and inspect cluster schemas
+# - kql_schema_memory: Discover, cache, and inspect cluster schemas
 ```
 ## 🔧 Quick Start
 
@@ -309,17 +334,24 @@ az login
 python -m mcp_kql_server
 ```
 
+To inspect the installed server version and runtime defaults:
+
+```bash
+python -m mcp_kql_server --info --json
+```
+
 The server starts immediately with:
 - 📁 **Auto-created memory path**: `%APPDATA%\KQL_MCP\cluster_memory`
 - 🔧 **Optimized defaults**: No configuration files needed
 - 🔐 **Secure setup**: Uses your existing Azure CLI credentials
+- ⚡ **Fast startup**: Auth and update checks are deferred unless explicitly enabled
 
 ### 3. Use via MCP Client
 
 The server provides two main tools:
 
 > #### `execute_kql_query` - Execute KQL queries or generate KQL from natural language
-> #### `schema_memory` - Discover, refresh, and inspect cached cluster schemas
+> #### `kql_schema_memory` - Discover, refresh, and inspect cached cluster schemas
 
 
 ## 💡 Usage Examples
@@ -416,7 +448,7 @@ graph LR
     end
     
     %% Client to Server
-    Client ==>|"📡 MCP Protocol<br/>STDIO/SSE"| FastMCP
+    Client ==>|"📡 MCP Protocol<br/>stdio or streamable HTTP"| FastMCP
     
     %% Server to Azure
     Executor ==>|"🔍 Execute KQL<br/>Query & Analyze"| ADX

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mcp-name: io.github.4R9UN/mcp-kql-server
 
 A Model Context Protocol (MCP) server that transforms natural language questions into optimized KQL queries with intelligent schema discovery, AI-powered caching, and seamless Azure Data Explorer integration. Simply ask questions in plain English and get instant, accurate KQL queries with context-aware results.
 
-**Latest Version: v2.1.3** - FastMCP v2 and v3 compatibility range, faster MCP startup, deferred Azure CLI auth, optional update checks, shared streamable HTTP transport, and SQLite concurrency hardening for multiple local MCP instances.
+**Latest Version: v2.1.4** - Canonical schema type normalization for sharper NL2KQL accuracy, credential redaction in logs, leaner dependencies, and a single-source package version.
 
 <!-- Badges Section -->
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,36 @@
 
 ---
 
+## 🚀 **v2.1.4 - NL2KQL Accuracy, Schema Type Normalization & Log Redaction**
+
+> **Sharpens NL2KQL generation accuracy and hardens logging, with no changes to the public tool contract.**
+
+**Release Date**: June 11, 2026
+**Author**: Arjun Trivedi
+**Email**: arjuntrivedi42@yahoo.com
+**Repository**: https://github.com/4R9UN/mcp-kql-server
+
+### 🎯 **What's New in v2.1.4**
+
+#### **1. Canonical Schema Type Normalization (NL2KQL accuracy)**
+- Schema discovery now normalizes every column type to a single canonical KQL vocabulary (`datetime`, `string`, `bool`, `int`, `long`, `real`, `decimal`, `guid`, `timespan`, `dynamic`) via a new `normalize_kql_type()` helper.
+- Previously, different discovery paths stored inconsistent type spellings (e.g. `Int64` / `DateTime` / `System.String`), so data-type-aware generation (time filters, aggregations, grouping) silently missed columns. Generation now keys off consistent types, producing more accurate, optimized queries.
+- CSL `ColumnType`/`CslType` is preferred over the .NET `DataType` when both are present.
+
+#### **2. Credential Redaction in Logs**
+- New `redact_secrets()` helper masks `user:pass@host`, `password=`/`token:` pairs, and `Bearer <jwt>` tokens before any raw query or connection string is logged.
+
+#### **3. Leaner Dependencies & Single-Source Version**
+- Removed unused `scikit-learn` and `authlib` dependencies; pinned `pandas>=1.3.0,<3.0.0`.
+- The package version now has a single literal source (`constants.py`), re-exported by `__init__.py` and enforced for parity with `pyproject.toml` and `server.json` in CI.
+
+### 🔄 **Upgrade**
+```bash
+pip install --upgrade mcp-kql-server==2.1.4
+```
+
+---
+
 ## 🚀 **v2.1.3 - FastMCP Compatibility, Faster Startup & Shared HTTP Transport**
 
 > **Modernizes startup behavior and MCP client configuration while keeping the public tool contract stable.**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,54 @@
 
 ---
 
+## 🚀 **v2.1.3 - FastMCP Compatibility, Faster Startup & Shared HTTP Transport**
+
+> **Modernizes startup behavior and MCP client configuration while keeping the public tool contract stable.**
+
+**Release Date**: May 9, 2026
+**Author**: Arjun Trivedi
+**Email**: arjuntrivedi42@yahoo.com
+**Repository**: https://github.com/4R9UN/mcp-kql-server
+
+### 🚀 **What's New in v2.1.3**
+
+#### **1. Faster MCP Startup**
+- `sentence_transformers` is now imported lazily, only when semantic embeddings are needed.
+- Startup update checks are opt in via `--check-updates` or `MCP_KQL_CHECK_FOR_UPDATES=true`.
+- Azure CLI auth is deferred by default so MCP tool discovery does not block on interactive login.
+
+#### **2. FastMCP Compatibility**
+- Runtime dependency range is now `fastmcp>=2.14.7,<4.0.0`.
+- Transport settings are passed through `mcp.run(...)`, which is compatible with FastMCP v2 and v3 patterns.
+- Latest FastMCP v3 import compatibility was validated in an isolated environment.
+
+#### **3. Shared HTTP Transport**
+- Added CLI and environment support for `stdio`, `http`, `streamable-http`, and `sse` transports.
+- `http` is normalized to modern streamable HTTP.
+- `--stateless-http` supports shared or multi worker deployments.
+
+#### **4. Multi Instance Local Memory**
+- SQLite connections now use WAL mode, `synchronous=NORMAL`, and `MCP_KQL_SQLITE_BUSY_TIMEOUT_MS`.
+- This reduces database lock failures when multiple stdio MCP instances share the same memory DB.
+
+#### **5. Documentation Cleanup**
+- README was simplified and now focuses on install, MCP settings, shared HTTP mode, runtime options, tools, security, and troubleshooting.
+- Removed noisy diagrams, repeated release details, demo clutter, and stale configuration snippets from the main README.
+
+### 🛡️ **Compatibility**
+
+- Public MCP tool names and return contract remain unchanged.
+- Stdio remains the default transport.
+- Shared HTTP mode is additive.
+
+### 📦 **Install**
+
+```bash
+pip install --upgrade mcp-kql-server==2.1.3
+```
+
+---
+
 ## 📝 **Documentation update — recommended MCP launch command**
 
 The recommended MCP client configuration now uses the Python module entry point:
@@ -61,7 +109,7 @@ This release focuses on execution reliability and NL2KQL accuracy. No new depend
 
 ### 🛡️ **Compatibility**
 
-- Public tool contract for `execute_kql_query` and `schema_memory` is unchanged.
+- Public tool contract for `execute_kql_query` and `kql_schema_memory` is unchanged.
 - The new `error_class` field is additive on error responses.
 - No new runtime dependencies. `ClientRequestProperties` is already shipped by `azure-kusto-data`.
 
@@ -90,7 +138,7 @@ This release focuses on correctness and schema fidelity. The server now prefers 
 
 #### **1. Stricter CAG and Schema Memory Usage**
 - **Schema-First Generation**: NL2KQL generation now uses ranked table and column context from schema memory before building candidate queries.
-- **Strict Table Context**: `schema_memory(operation="get_context")` can now be scoped to a specific table and returns:
+- **Strict Table Context**: `kql_schema_memory(operation="get_context")` can now be scoped to a specific table and returns:
   - allowed columns
   - recommended columns
   - preferred time column
@@ -104,7 +152,7 @@ This release focuses on correctness and schema fidelity. The server now prefers 
 
 #### **3. Cache and Runtime Stability**
 - **Scoped Query Cache**: Cached results are now isolated by query text, cluster, database, and cache namespace.
-- **Safe Cache Clearing**: `schema_memory(operation="clear_cache")` now clears real cached state rather than only returning a success message.
+- **Safe Cache Clearing**: `kql_schema_memory(operation="clear_cache")` now clears real cached state rather than only returning a success message.
 - **Shared Connection Pooling**: Execution paths now use the shared pool instead of a duplicate local client cache path.
 - **Safer Health Checks**: Pool health checks probe only with a registered database and avoid false recycling when no database context exists.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference - MCP KQL Server
 
-**Version**: 2.1.2
+**Version**: 2.1.3
 **Last Updated**: December 2025
 
 ---
@@ -91,7 +91,7 @@ result = await execute_kql_query(
 
 ---
 
-### 1.2 schema_memory
+### 1.2 kql_schema_memory
 
 Manage schema discovery, caching, and AI context generation.
 
@@ -579,8 +579,16 @@ formatted = schema_mgr.format_schema_for_display(schema_dict)
 | `KQL_MEMORY_PATH` | Custom memory DB path | Auto |
 | `KQL_LOG_LEVEL` | Logging level | INFO |
 | `KQL_POOL_SIZE` | Connection pool size | 10 |
+| `FASTMCP_TRANSPORT` | Server transport: `stdio`, `http`, `streamable-http`, or `sse` | `stdio` |
+| `FASTMCP_HOST` | HTTP bind host | `127.0.0.1` |
+| `FASTMCP_PORT` | HTTP bind port | `8000` |
+| `FASTMCP_STREAMABLE_HTTP_PATH` | Streamable HTTP endpoint path | `/mcp` |
+| `FASTMCP_STATELESS_HTTP` | Stateless HTTP mode for shared deployments | `false` |
+| `MCP_KQL_AUTH_ON_STARTUP` | Check Azure CLI auth before server startup | `false` |
+| `MCP_KQL_CHECK_FOR_UPDATES` | Check PyPI for package updates at startup | `false` |
+| `MCP_KQL_SQLITE_BUSY_TIMEOUT_MS` | SQLite busy timeout for concurrent MCP instances | `30000` |
 
-> **Hardcoded server-side ceiling**: As of v2.1.2 every Kusto call ships
+> **Hardcoded server-side ceiling**: As of v2.1.3 every Kusto call ships
 > `ClientRequestProperties.servertimeout` clamped to `KUSTO_MAX_QUERY_TIMEOUT_SECONDS = 600`
 > (10 minutes). Caller-supplied values above this ceiling are silently clamped.
 > See `mcp_kql_server/constants.py` and `mcp_kql_server/execute_kql.py:_build_request_properties`.
@@ -602,16 +610,32 @@ from mcp_kql_server.constants import (
 
 ### 6.3 MCP Configuration (mcp.json)
 
+Stdio mode is recommended for local clients:
+
 ```json
 {
-    "mcpServers": {
-        "kql-server": {
+    "servers": {
+        "mcpKqlServer": {
+            "type": "stdio",
             "command": "python",
-            "args": ["-m", "mcp_kql_server"],
-            "env": {
-                "KQL_QUERY_TIMEOUT": "300",
-                "KQL_LOG_LEVEL": "INFO"
-            }
+            "args": ["-m", "mcp_kql_server"]
+        }
+    }
+}
+```
+
+Shared HTTP mode lets multiple MCP clients connect to one running server:
+
+```bash
+python -m mcp_kql_server --transport http --host 127.0.0.1 --port 8000 --http-path /mcp --stateless-http
+```
+
+```json
+{
+    "servers": {
+        "mcpKqlServer": {
+            "type": "http",
+            "url": "http://127.0.0.1:8000/mcp"
         }
     }
 }
@@ -623,6 +647,7 @@ from mcp_kql_server.constants import (
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2.1.3 | May 2026 | FastMCP 3 compatibility range, faster startup, lazy auth, shared HTTP transport, SQLite concurrency hardening, README cleanup |
 | 2.1.2 | May 2026 | Hardcoded 10-min Kusto servertimeout, ADX dry-run validation, schema-drift recovery loop, schema-driven NL2KQL |
 | 2.1.1 | Dec 2025 | Improved CAG ranking, cache scoping, and runtime stability |
 | 2.1.0 | Dec 2025 | Schema-only NL2KQL, version checker |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference - MCP KQL Server
 
-**Version**: 2.1.3
+**Version**: 2.1.4
 **Last Updated**: December 2025
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # MCP KQL Server Architecture
 
-**Version**: 2.1.3
+**Version**: 2.1.4
 **Author**: Arjun Trivedi
 **Email**: arjuntrivedi42@yahoo.com
 **Last Updated**: December 2025
@@ -64,7 +64,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
                                      │
                                      ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                        MCP KQL Server (v2.1.3)                               │
+│                        MCP KQL Server (v2.1.4)                               │
 │                                                                              │
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
 │  │                         API Layer (mcp_server.py)                       │ │
@@ -636,7 +636,7 @@ from mcp_kql_server import (
 
 ## Conclusion
 
-The MCP KQL Server v2.1.3 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. Key enhancements in this version include:
+The MCP KQL Server v2.1.4 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. Key enhancements in this version include:
 
 - **Configurable TTL Cache**: Query-type-aware caching with automatic expiration
 - **Multi-Cluster Support**: Track and query tables across multiple Azure Data Explorer clusters

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # MCP KQL Server Architecture
 
-**Version**: 2.1.2
+**Version**: 2.1.3
 **Author**: Arjun Trivedi
 **Email**: arjuntrivedi42@yahoo.com
 **Last Updated**: December 2025
@@ -60,16 +60,16 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
           │                 │                 │                 │
           └─────────────────┴────────┬────────┴─────────────────┘
                                      │
-                            MCP Protocol (stdio)
+                           MCP Protocol (stdio or streamable HTTP)
                                      │
                                      ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                        MCP KQL Server (v2.1.1)                               │
+│                        MCP KQL Server (v2.1.3)                               │
 │                                                                              │
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
 │  │                         API Layer (mcp_server.py)                       │ │
 │  │  ┌─────────────────────────┐  ┌─────────────────────────────────────┐  │ │
-│  │  │  execute_kql_query      │  │  schema_memory                      │  │ │
+│  │  │  execute_kql_query      │  │  kql_schema_memory                  │  │ │
 │  │  │  - Direct KQL execution │  │  - discover, list_tables, get_context│ │ │
 │  │  │  - NL2KQL generation    │  │  - generate_report, clear_cache     │  │ │
 │  │  └─────────────────────────┘  └─────────────────────────────────────┘  │ │
@@ -151,7 +151,7 @@ The MCP KQL Server is an AI-augmented service for executing Kusto Query Language
 
 | Module | Purpose | Key Classes/Functions |
 |--------|---------|----------------------|
-| `mcp_server.py` | MCP tool registration & routing | `execute_kql_query()`, `schema_memory()` |
+| `mcp_server.py` | MCP tool registration & routing | `execute_kql_query()`, `kql_schema_memory` (`schema_memory()` function) |
 | `execute_kql.py` | KQL execution engine | `kql_execute_tool()`, `_get_kusto_client()` |
 | `memory.py` | Persistent schema storage | `MemoryManager`, `SemanticSearch` |
 | `utils.py` | Utilities & helpers | `normalize_cluster_uri()`, `bracket_if_needed()`, `ErrorHandler`, `SchemaManager` |
@@ -530,7 +530,7 @@ The server tracks which tables exist in which clusters/databases:
 │  - get_all_table_locations() -> Dict[str, List[Dict]]            │
 │  - remove_table_location(table, cluster, database)               │
 │                                                                  │
-│  MCP Operations (schema_memory tool):                            │
+│  MCP Operations (kql_schema_memory tool):                        │
 │  - list_multi_cluster_tables: List all tracked tables            │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
@@ -636,11 +636,11 @@ from mcp_kql_server import (
 
 ## Conclusion
 
-The MCP KQL Server v2.1.1 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. Key enhancements in this version include:
+The MCP KQL Server v2.1.3 architecture provides a robust, performant, and secure foundation for AI-augmented KQL query execution. Key enhancements in this version include:
 
 - **Configurable TTL Cache**: Query-type-aware caching with automatic expiration
 - **Multi-Cluster Support**: Track and query tables across multiple Azure Data Explorer clusters
 - **Health Check Scheduling**: Background connection health monitoring and automatic cleanup
-- **Enhanced Statistics**: Detailed cache and memory statistics via new schema_memory operations
+- **Enhanced Statistics**: Detailed cache and memory statistics via new kql_schema_memory operations
 
 For questions or contributions, please refer to [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide - MCP KQL Server
 
-**Version**: 2.1.3
+**Version**: 2.1.4
 **Last Updated**: December 2025
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide - MCP KQL Server
 
-**Version**: 2.1.2
+**Version**: 2.1.3
 **Last Updated**: December 2025
 
 ---
@@ -226,12 +226,12 @@ for dep in deps:
 
 2. **Refresh schema cache:**
    ```text
-   schema_memory(operation="refresh_schema", cluster_url="...", database="...")
+   kql_schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
 
 3. **Use schema memory tool:**
    ```
-   schema_memory(operation="discover", cluster_url="...", database="...", table_name="...")
+   kql_schema_memory(operation="discover", cluster_url="...", database="...", table_name="...")
    ```
 
 ---
@@ -246,7 +246,7 @@ for dep in deps:
 1. **List available tables:**
    ```python
    # Via MCP tool
-   schema_memory(operation="list_tables", cluster_url="...", database="...")
+   kql_schema_memory(operation="list_tables", cluster_url="...", database="...")
    ```
 
 2. **Check table name case sensitivity:**
@@ -329,12 +329,12 @@ for dep in deps:
 
 1. **Force schema refresh:**
    ```text
-   schema_memory(operation="refresh_schema", cluster_url="...", database="...")
+   kql_schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
 
 2. **Use refresh_schema operation:**
    ```
-   schema_memory(operation="refresh_schema", cluster_url="...", database="...")
+   kql_schema_memory(operation="refresh_schema", cluster_url="...", database="...")
    ```
 
 ---
@@ -354,7 +354,7 @@ for dep in deps:
 
 1. **Request strict table-scoped context before generating KQL:**
    ```
-   schema_memory(
+   kql_schema_memory(
      operation="get_context",
      cluster_url="...",
      database="...",
@@ -411,7 +411,7 @@ for dep in deps:
 
 2. **Rediscover schemas to generate embeddings:**
    ```python
-   schema_memory(operation="discover", cluster_url="...", database="...", table_name="TableName")
+   kql_schema_memory(operation="discover", cluster_url="...", database="...", table_name="TableName")
    ```
 
 3. **Check sentence-transformers installation:**
@@ -540,15 +540,15 @@ for dep in deps:
 
 **Cause:** The VS Code Python extension intercepts a bare `"command": "python"` and substitutes its **cached selected interpreter** path. If that interpreter was uninstalled or upgraded, the spawn fails. `pip install` cannot prevent this; the path is stored by VS Code, not derived from `PATH`.
 
-**Fix (preferred):** invoke through the platform-stable launcher so the spawn cannot be hijacked by the Python extension's cached interpreter:
+**Fix (preferred):** invoke through the platform-stable launcher so the spawn cannot be hijacked by the Python extension's cached interpreter. On Windows, run `Get-Command py` if you need the full launcher path:
 
 ```json
 {
     "servers": {
-        "mcp-kql-server": {
+      "mcpKqlServer": {
             "type": "stdio",
-            "command": "python",
-            "args": ["-m", "mcp_kql_server"]
+         "command": "py",
+         "args": ["-3", "-m", "mcp_kql_server"]
         }
     }
 }
@@ -559,7 +559,7 @@ for dep in deps:
 ```json
 {
     "servers": {
-        "mcp-kql-server": {
+   "mcpKqlServer": {
             "type": "stdio",
             "command": "mcp-kql-server",
             "args": []
@@ -569,6 +569,21 @@ for dep in deps:
 ```
 
 Do **not** use the bare string `"python"` on Windows when the VS Code Python extension is installed.
+
+### Problem: VS Code starts the server but shows no KQL tools
+
+**Symptom:** Running `python -m mcp_kql_server` works, and a protocol probe returns `execute_kql_query` and `kql_schema_memory`, but the VS Code tool picker stays empty.
+
+**Cause:** VS Code stores MCP trust decisions and cached tool lists separately from `mcp.json`. If the server previously failed with a stale Python path, VS Code can keep the old empty discovery state until the cache is reset.
+
+**Fix:**
+
+1. Run `MCP: Reset Cached Tools` from the Command Palette.
+2. Run `MCP: Reset Trust` from the Command Palette.
+3. Run `MCP: List Servers`, choose `mcpKqlServer`, then choose restart.
+4. Open the KQL server output log and confirm it lists `execute_kql_query` and `kql_schema_memory`.
+
+Using a camelCase key such as `mcpKqlServer` also follows VS Code naming guidance and forces fresh discovery if the old `mcp-kql-server` entry had stale failed state.
 
 ### Problem: Server not detected by Claude
 

--- a/mcp_kql_server/__init__.py
+++ b/mcp_kql_server/__init__.py
@@ -20,7 +20,7 @@ from .mcp_server import main
 from .version_checker import check_for_updates, get_current_version
 
 # Version information
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 __author__ = "Arjun Trivedi"
 __email__ = "arjuntrivedi42@yahoo.com"
 
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 def _setup_memory_directories():
     """Initialize unified data directory and corpus file on import."""
     try:
-        from .constants import get_data_dir
+        from .constants import format_display_path, get_data_dir
         from .memory import get_memory_manager
 
         # Ensure unified data dir exists
@@ -64,7 +64,7 @@ def _setup_memory_directories():
         mm = get_memory_manager()
         mm.save_corpus()
         # Use canonical attribute name `memory_path` directly; avoid deprecated alias `corpus_path`
-        logger.info("Unified memory initialized at: %s", mm.memory_path)
+        logger.info("Unified memory initialized at: %s", format_display_path(mm.memory_path))
     except (OSError, RuntimeError, ImportError) as e:
         # Narrow exception types to avoid masking unexpected failures
         logger.debug("Unified memory setup skipped: %s", e)

--- a/mcp_kql_server/__init__.py
+++ b/mcp_kql_server/__init__.py
@@ -19,8 +19,8 @@ from .execute_kql import execute_kql_query
 from .mcp_server import main
 from .version_checker import check_for_updates, get_current_version
 
-# Version information
-__version__ = "2.1.3"
+# Version information - single source of truth lives in constants.py
+__version__ = VERSION
 __author__ = "Arjun Trivedi"
 __email__ = "arjuntrivedi42@yahoo.com"
 

--- a/mcp_kql_server/__main__.py
+++ b/mcp_kql_server/__main__.py
@@ -3,6 +3,9 @@ Entry point for running the MCP KQL Server as a module.
 
 This file allows the package to be executed directly with:
 python -m mcp_kql_server
+
+Author: Arjun Trivedi
+Email: arjuntrivedi42@yahoo.com
 """
 
 from .mcp_server import main

--- a/mcp_kql_server/constants.py
+++ b/mcp_kql_server/constants.py
@@ -17,8 +17,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-# Version information - Single source of truth from pyproject.toml
-__version__ = "2.1.3"
+# Version information - single source of truth for the package version.
+# Keep this in sync with pyproject.toml and server.json (CI enforces parity).
+__version__ = "2.1.4"
 VERSION = __version__
 MCP_PROTOCOL_VERSION = "2024-11-05"
 

--- a/mcp_kql_server/constants.py
+++ b/mcp_kql_server/constants.py
@@ -11,12 +11,14 @@ Email: arjuntrivedi42@yahoo.com
 
 import os
 import re
+import ntpath
+import posixpath
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
 # Version information - Single source of truth from pyproject.toml
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 VERSION = __version__
 MCP_PROTOCOL_VERSION = "2024-11-05"
 
@@ -91,7 +93,7 @@ FASTAPI_HOST = "0.0.0.0"
 FASTAPI_PORT = 8000
 
 # Tool Configuration
-TOOL_KQL_EXECUTE_NAME = "kql_execute"
+TOOL_KQL_EXECUTE_NAME = "execute_kql_query"
 TOOL_KQL_EXECUTE_DESCRIPTION = """Execute KQL (Kusto Query Language) queries for Azure Data Explorer, Application Insights, Log Analytics, and other Kusto databases.
 
 **Use this tool when users ask about:**
@@ -114,6 +116,10 @@ TOOL_KQL_EXECUTE_DESCRIPTION = """Execute KQL (Kusto Query Language) queries for
 Supports both direct KQL execution and natural language to KQL conversion with intelligent schema detection."""
 
 TOOL_KQL_SCHEMA_NAME = "kql_schema_memory"
+REGISTERED_TOOL_NAMES = (
+    TOOL_KQL_EXECUTE_NAME,
+    TOOL_KQL_SCHEMA_NAME,
+)
 TOOL_KQL_SCHEMA_DESCRIPTION = """Discover database schemas, table structures, and generate KQL queries using AI-powered schema intelligence.
 
 **Use this tool when users need:**
@@ -447,6 +453,39 @@ KQL_CONVERSATIONAL_PENALTY = -0.5
 
 # Memory configuration - default memory path under %APPDATA%/KQL_MCP on Windows; fallback to user's home when not set
 DEFAULT_MEMORY_PATH = str(Path(os.environ.get("APPDATA", str(Path.home()))) / "KQL_MCP" / "kql_mcp_memory.json")
+
+
+def format_display_path(path: Any) -> str:
+    """Return a user-safe display path for logs and diagnostics.
+
+    Runtime paths can include a local profile directory. For user-facing output,
+    replace well-known profile roots with environment variable placeholders while
+    leaving the actual storage path unchanged.
+    """
+    path_text = str(path)
+    if not path_text:
+        return path_text
+
+    for env_name, placeholder in (
+        ("APPDATA", "%APPDATA%"),
+        ("LOCALAPPDATA", "%LOCALAPPDATA%"),
+        ("USERPROFILE", "%USERPROFILE%"),
+        ("HOME", "~"),
+    ):
+        env_value = os.environ.get(env_name)
+        if not env_value:
+            continue
+        for path_module, separator in ((os.path, os.sep), (ntpath, "\\"), (posixpath, "/")):
+            normalized_path = path_module.normcase(path_module.normpath(path_text))
+            normalized_env = path_module.normcase(path_module.normpath(env_value))
+            if normalized_path == normalized_env:
+                return placeholder
+            if normalized_path.startswith(normalized_env + separator):
+                suffix = path_module.normpath(path_text)[len(path_module.normpath(env_value)):].lstrip("\\/")
+                display_separator = "\\" if "\\" in path_text else "/"
+                return f"{placeholder}{display_separator}{suffix}" if suffix else placeholder
+
+    return path_text
 
 # Query execution configuration
 DEFAULT_MAX_RETRIES = 3

--- a/mcp_kql_server/execute_kql.py
+++ b/mcp_kql_server/execute_kql.py
@@ -35,6 +35,7 @@ from .utils import (
     extract_tables_from_query,
     generate_query_description,
     normalize_cluster_uri,
+    redact_secrets,
     retry_on_exception
 )
 
@@ -289,7 +290,7 @@ def _execute_kusto_query_sync(kql_query: str, cluster: str, database: str, timeo
     crp = _build_request_properties(timeout, kql_query)
     logger.info(
         "Executing KQL on %s/%s [request_id=%s timeout=%ss]: %s...",
-        cluster_url, database, crp.client_request_id, _clamp_timeout(timeout), kql_query[:150],
+        cluster_url, database, crp.client_request_id, _clamp_timeout(timeout), redact_secrets(kql_query[:150]),
     )
 
     get_connection_pool().register_health_check_database(cluster_url, database)
@@ -453,7 +454,7 @@ def kql_execute_tool(kql_query: str, cluster_uri: Optional[str] = None, database
 
     except (ValueError, TypeError, RuntimeError, AttributeError) as e:
         logger.error("kql_execute_tool failed pre-execution: %s", e)
-        logger.error("Original query was: %s", kql_query if 'kql_query' in locals() else 'Unknown')
+        logger.error("Original query was: %s", redact_secrets(kql_query) if 'kql_query' in locals() else 'Unknown')
         raise  # Re-raise instead of returning empty DataFrame
 
 

--- a/mcp_kql_server/kql_auth.py
+++ b/mcp_kql_server/kql_auth.py
@@ -8,6 +8,7 @@ Supports AzureCliCredential for async clients.
 Author: Arjun Trivedi
 Email: arjuntrivedi42@yahoo.com
 """
+# pylint: disable=broad-exception-caught
 
 import subprocess
 import platform
@@ -20,6 +21,9 @@ from azure.identity import AzureCliCredential
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+AUTH_CHECK_TIMEOUT_SECONDS = int(os.environ.get("MCP_KQL_AUTH_CHECK_TIMEOUT_SECONDS", "10"))
+AUTH_LOGIN_TIMEOUT_SECONDS = int(os.environ.get("MCP_KQL_AUTH_LOGIN_TIMEOUT_SECONDS", "120"))
 
 @lru_cache(maxsize=1)
 def get_azure_credential() -> AzureCliCredential:
@@ -44,14 +48,14 @@ def kql_auth():
         env = os.environ.copy()
         subprocess.run(
             [az_command, "config", "set", "core.login_experience_v2=off"],
-            env=env, capture_output=True, text=True, check=True, timeout=60
+            env=env, capture_output=True, text=True, check=True, timeout=AUTH_CHECK_TIMEOUT_SECONDS
         )
         subprocess.run(
             [az_command, "account", "get-access-token"],
-            env=env, capture_output=True, text=True, check=True, timeout=60
+            env=env, capture_output=True, text=True, check=True, timeout=AUTH_CHECK_TIMEOUT_SECONDS
         )
         logger.info("User is authenticated with Azure CLI.")
-        return {"authenticated": True, "message": "User is authenticated."}
+        return {"authenticated": True, "message": "User is authenticated.", "auth_method": "azure-cli"}
     except subprocess.TimeoutExpired:
         logger.error("Authentication check timed out.")
         return {"authenticated": False, "message": "Authentication check timed out."}
@@ -81,15 +85,15 @@ def trigger_az_cli_auth():
     try:
         subprocess.run(
             [az_command, "config", "set", "core.login_experience_v2=off"],
-            env=env, capture_output=True, text=True, check=True, timeout=60
+            env=env, capture_output=True, text=True, check=True, timeout=AUTH_CHECK_TIMEOUT_SECONDS
         )
         auth_result = subprocess.run(
             [az_command, "login", "--use-device-code"],
-            capture_output=True, text=True, env=env, timeout=120, check=False
+            capture_output=True, text=True, env=env, timeout=AUTH_LOGIN_TIMEOUT_SECONDS, check=False
         )
         if auth_result.returncode == 0:
             logger.info("Azure CLI login successful.")
-            return {"authenticated": True, "message": "Azure CLI login successful."}
+            return {"authenticated": True, "message": "Azure CLI login successful.", "auth_method": "azure-cli"}
         logger.error("Azure CLI login failed: %s", auth_result.stderr)
         return {"authenticated": False, "message": auth_result.stderr}
     except subprocess.TimeoutExpired:
@@ -99,9 +103,13 @@ def trigger_az_cli_auth():
         logger.error("Authentication attempt failed: %s", str(e))
         return {"authenticated": False, "message": str(e)}
 
-def authenticate():
+def authenticate(interactive: bool = True):
     """
     Complete authentication flow with caching and retry logic.
+
+    Args:
+        interactive: If False, never starts device-code login. This keeps MCP
+            startup and tool discovery fast in hosts that cannot answer prompts.
 
     Returns:
         dict: Final authentication status and message
@@ -114,6 +122,14 @@ def authenticate():
         return auth_status
 
     logger.info("Not authenticated. Initiating Azure login...")
+    if not interactive:
+        return {
+            "authenticated": False,
+            "message": "Azure CLI is not authenticated. Run 'az login' in a terminal, then retry.",
+            "auth_method": "azure-cli",
+            "interactive_required": True,
+        }
+
     auth_status = trigger_az_cli_auth()
 
     if not auth_status["authenticated"]:
@@ -125,14 +141,18 @@ def authenticate():
 
     return auth_status
 
-def authenticate_kusto() -> Dict[str, Any]:
+def authenticate_kusto(interactive: bool = True) -> Dict[str, Any]:
     """
     Wrapper function for compatibility with existing code.
+
+    Args:
+        interactive: If False, skip device-code login and return a structured
+            unauthenticated status instead.
 
     Returns:
         dict: Authentication status and message
     """
-    return authenticate()
+    return authenticate(interactive=interactive)
 
 if __name__ == "__main__":
     result = authenticate()

--- a/mcp_kql_server/mcp_server.py
+++ b/mcp_kql_server/mcp_server.py
@@ -42,6 +42,7 @@ from .memory import get_memory_manager
 from .utils import (
     bracket_if_needed, SchemaManager, ErrorHandler,
     extract_cluster_and_database_from_query,
+    redact_secrets,
 )
 from .kql_auth import authenticate_kusto
 from .kql_validator import KQLValidator
@@ -934,7 +935,7 @@ async def execute_kql_query(
                 return json.dumps(result, indent=2)
 
         if df is None or df.empty:
-            logger.info("Query returned empty result (no rows) for: %s...", query[:100])
+            logger.info("Query returned empty result (no rows) for: %s...", redact_secrets(query[:100]))
             result = {
                 "success": True,
                 "error": None,

--- a/mcp_kql_server/mcp_server.py
+++ b/mcp_kql_server/mcp_server.py
@@ -5,6 +5,7 @@ Clean server with 2 main tools and single authentication
 Author: Arjun Trivedi
 Email: arjuntrivedi42@yahoo.com
 """
+# pylint: disable=broad-exception-caught,unused-argument
 
 import json
 import logging
@@ -22,10 +23,13 @@ os.environ["FASTMCP_NO_BANNER"] = "1"
 os.environ["FASTMCP_SUPPRESS_BRANDING"] = "1"
 os.environ["NO_COLOR"] = "1"
 
-from fastmcp import FastMCP # pylint: disable=wrong-import-position
+from fastmcp import FastMCP
 
 from .constants import (
     SERVER_NAME,
+    REGISTERED_TOOL_NAMES,
+    TOOL_KQL_EXECUTE_NAME,
+    TOOL_KQL_SCHEMA_NAME,
     __version__,
 )
 from .execute_kql import (
@@ -43,6 +47,14 @@ from .kql_auth import authenticate_kusto
 from .kql_validator import KQLValidator
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean environment variable."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 # Server-level instructions surfaced to MCP clients (Claude, VS Code, Cursor, ...)
 # in their tool-discovery UI. Keep concise and action-oriented; LLMs use this to
@@ -104,6 +116,15 @@ kql_validator = KQLValidator(memory_manager, schema_manager)
 
 # Global kusto manager - will be set at startup
 kusto_manager_global = None
+
+
+def _ensure_kusto_authenticated() -> Dict[str, Any]:
+    """Perform a lazy, non-interactive Azure CLI auth check."""
+    global kusto_manager_global  # pylint: disable=global-statement
+    if isinstance(kusto_manager_global, dict) and kusto_manager_global.get("authenticated"):
+        return kusto_manager_global
+    kusto_manager_global = authenticate_kusto(interactive=False)
+    return kusto_manager_global
 
 GENERATION_STOPWORDS = {
     "a", "an", "and", "are", "as", "at", "by", "find", "for", "from", "get",
@@ -626,7 +647,7 @@ def _build_safe_repair_query(
 
 
 @mcp.tool(
-    name="execute_kql_query",
+    name=TOOL_KQL_EXECUTE_NAME,
     title="Execute KQL Query (Azure Data Explorer / Kusto)",
     annotations={
         # Direct queries are read-only; .ingest/.drop management commands are rare
@@ -694,11 +715,13 @@ async def execute_kql_query(
     """
     try:
         repaired_query_info = None
-        if not kusto_manager_global or not kusto_manager_global.get("authenticated"):
+        auth_status = _ensure_kusto_authenticated()
+        if not auth_status or not auth_status.get("authenticated"):
             return json.dumps({
                 "success": False,
                 "error": "Authentication required",
-                "suggestions": ["Run 'az login' to authenticate"]
+                "auth_status": auth_status,
+                "suggestions": ["Run 'az login' in a terminal, then retry the tool call"]
             })
 
         # If caller did not pass cluster/database, try to recover them from any
@@ -875,21 +898,21 @@ async def execute_kql_query(
                 if "database" in error_str and ("not found" in error_str or "kind" in error_str):
                     suggestions.extend([
                         f"Database '{database}' was not found on cluster '{cluster_url}'",
-                        "Run schema_memory(operation='list_tables', cluster_url=<cluster>, database=<db>) to confirm the database name",
+                        "Run kql_schema_memory(operation='list_tables', cluster_url=<cluster>, database=<db>) to confirm the database name",
                         "Use '.show databases' as a KQL query to list available databases on the cluster",
                     ])
                 # Table/Column not found errors (SEM0100)
                 elif "sem0100" in error_str or "failed to resolve" in error_str:
                     suggestions.extend([
                         "One or more column names don't exist in the table schema",
-                        "Run schema_memory(operation='discover', table_name='<table>') to refresh schema",
+                        "Run kql_schema_memory(operation='discover', table_name='<table>') to refresh schema",
                         "Check column names using: TableName | getschema"
                     ])
                 # Unknown table errors
                 elif "unknown" in error_str and "table" in error_str:
                     suggestions.extend([
                         "Table name may be incorrect",
-                        "Run: schema_memory(operation='list_tables') to see available tables",
+                        "Run: kql_schema_memory(operation='list_tables') to see available tables",
                         "Check if you need to use bracket notation: ['TableName']"
                     ])
                 else:
@@ -1065,7 +1088,7 @@ async def _generate_kql_from_natural_language(
                     "success": False,
                     "error": f"No schema found for {SPECIAL_TOKENS['TABLE_START']}{table_name}{SPECIAL_TOKENS['TABLE_END']} in memory.",
                     "query": "",
-                    "suggestion": f"Run: schema_memory(operation='discover', cluster_url='{cluster_url}', database='{database}', table_name='{table_name}')",
+                    "suggestion": f"Run: kql_schema_memory(operation='discover', cluster_url='{cluster_url}', database='{database}', table_name='{table_name}')",
                 }
 
             explicit_table = {
@@ -1099,7 +1122,7 @@ async def _generate_kql_from_natural_language(
                 "success": False,
                 "error": f"{SPECIAL_TOKENS['CLUSTER_START']}ERROR{SPECIAL_TOKENS['CLUSTER_END']} Could not determine a relevant table from schema memory.",
                 "query": "",
-                "suggestion": "Use schema_memory(operation='list_tables') or pass table_name explicitly before generating queries.",
+                "suggestion": "Use kql_schema_memory(operation='list_tables') or pass table_name explicitly before generating queries.",
             }
 
         validated_candidates = []
@@ -1272,7 +1295,7 @@ async def _generate_kql_from_natural_language(
 
 
 @mcp.tool(
-    name="kql_schema_memory",
+    name=TOOL_KQL_SCHEMA_NAME,
     title="KQL Schema Memory & Discovery (Kusto)",
     annotations={
         "readOnlyHint": True,
@@ -1323,13 +1346,15 @@ async def schema_memory(
     Authentication: Requires `az login` first.
     """
     try:
-        if not kusto_manager_global or not kusto_manager_global.get("authenticated"):
+        auth_status = _ensure_kusto_authenticated()
+        if not auth_status or not auth_status.get("authenticated"):
             return json.dumps({
                 "success": False,
                 "error": "Authentication required",
+                "auth_status": auth_status,
                 "suggestions": [
                     "Ensure Azure CLI is installed and authenticated",
-                    "Run 'az login' to authenticate",
+                    "Run 'az login' in a terminal, then retry the tool call",
                     "Check your Azure permissions"
                 ]
             })
@@ -1694,7 +1719,7 @@ async def _schema_list_tables_operation(cluster_url: str, database: str) -> str:
             "tables": tables,
             "table_tokens": table_tokens,
             "count": len(tables),
-            "note": f"{SPECIAL_TOKENS['AI_START']}Use schema_memory(operation='discover', table_name='<table>') to get column details{SPECIAL_TOKENS['AI_END']}"
+            "note": f"{SPECIAL_TOKENS['AI_START']}Use kql_schema_memory(operation='discover', table_name='<table>') to get column details{SPECIAL_TOKENS['AI_END']}"
         }, indent=2)
     except (ValueError, RuntimeError, OSError) as e:
         return json.dumps({
@@ -2039,10 +2064,10 @@ def _print_info(as_json: bool = False) -> None:
         tools_info = []
     if not tools_info:
         tools_info = [
-            {"name": "execute_kql_query",
+            {"name": TOOL_KQL_EXECUTE_NAME,
              "title": "Execute KQL Query (Azure Data Explorer / Kusto)",
              "summary": "Run KQL on Kusto and return results. Supports NL2KQL via generate_query=true."},
-            {"name": "kql_schema_memory",
+            {"name": TOOL_KQL_SCHEMA_NAME,
              "title": "KQL Schema Memory & Discovery (Kusto)",
              "summary": "Discover, cache and explore Kusto schema. Operations: list_tables, discover, get_context, refresh_schema, get_stats, clear_cache, generate_report, cache_stats, cleanup_cache, list_multi_cluster_tables."},
         ]
@@ -2053,7 +2078,7 @@ def _print_info(as_json: bool = False) -> None:
         "mcp_protocol_version": C.MCP_PROTOCOL_VERSION,
         "transport": "stdio (FastMCP)",
         "auth": "Azure CLI (az login). No secrets stored.",
-        "memory_path": C.DEFAULT_MEMORY_PATH,
+        "memory_path": C.format_display_path(C.DEFAULT_MEMORY_PATH),
         "default_kusto_domain": C.DEFAULT_KUSTO_DOMAIN,
         "connection_timeout_sec": C.DEFAULT_CONNECTION_TIMEOUT,
         "query_timeout_sec": C.DEFAULT_QUERY_TIMEOUT,
@@ -2125,6 +2150,46 @@ def main():
         "--json", action="store_true",
         help="With --info, emit machine-readable JSON instead of text.",
     )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http", "streamable-http", "sse"],
+        default=os.environ.get("FASTMCP_TRANSPORT", "stdio"),
+        help="Transport for FastMCP. Defaults to stdio; use http for a shared server.",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("FASTMCP_HOST", "127.0.0.1"),
+        help="Host for HTTP transports.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("FASTMCP_PORT", "8000")),
+        help="Port for HTTP transports.",
+    )
+    parser.add_argument(
+        "--http-path",
+        default=os.environ.get("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp"),
+        help="Path for streamable HTTP transport.",
+    )
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        default=_env_flag("FASTMCP_STATELESS_HTTP", False),
+        help="Run HTTP transport in stateless mode for multi-worker deployments.",
+    )
+    parser.add_argument(
+        "--auth-on-startup",
+        action="store_true",
+        default=_env_flag("MCP_KQL_AUTH_ON_STARTUP", False),
+        help="Check Azure CLI auth before starting. Disabled by default for faster MCP discovery.",
+    )
+    parser.add_argument(
+        "--check-updates",
+        action="store_true",
+        default=_env_flag("MCP_KQL_CHECK_FOR_UPDATES", False),
+        help="Check PyPI for mcp-kql-server updates at startup. Disabled by default.",
+    )
 
     args = parser.parse_args()
 
@@ -2141,34 +2206,52 @@ def main():
     logger.info("MCP KQL Server v%s", get_current_version())
     logger.info("=" * 60)
 
-    # Check for updates at startup (non-blocking, with short timeout)
-    try:
-        update_available, update_msg = startup_version_check(auto_update=False, silent=False)
-        if update_available:
-            logger.info("-" * 60)
-            logger.info("UPDATE AVAILABLE: %s", update_msg)
-            logger.info("Run: pip install --upgrade mcp-kql-server")
-            logger.info("-" * 60)
-    except Exception as e:
-        logger.debug("Version check skipped: %s", e)
+    if args.check_updates:
+        try:
+            update_available, update_msg = startup_version_check(auto_update=False, silent=False)
+            if update_available:
+                logger.info("-" * 60)
+                logger.info("UPDATE AVAILABLE: %s", update_msg)
+                logger.info("Run: pip install --upgrade mcp-kql-server")
+                logger.info("-" * 60)
+        except (RuntimeError, OSError, ValueError, TypeError) as e:
+            logger.debug("Version check skipped: %s", e)
+    else:
+        logger.info("[OK] Startup update check disabled")
 
     try:
-        # Single authentication at startup
-        kusto_manager_global = authenticate_kusto()
+        if args.auth_on_startup:
+            kusto_manager_global = authenticate_kusto(interactive=False)
+        else:
+            kusto_manager_global = {"authenticated": False, "message": "Auth check deferred until first Kusto tool call"}
 
-        if kusto_manager_global["authenticated"]:
+        if kusto_manager_global.get("authenticated"):
             logger.info("[OK] Authentication successful")
             logger.info("[OK] MCP KQL Server ready")
         else:
-            logger.warning("[WARN] Authentication failed - some operations may not work")
-            logger.info("[OK] MCP KQL Server starting in limited mode")
+            logger.info("[OK] Authentication deferred. Run 'az login' before executing KQL.")
+            logger.info("[OK] MCP KQL Server ready")
 
         # Log available tools
-        logger.info("Available tools: execute_kql_query, schema_memory")
+        logger.info("Available tools: %s", ", ".join(REGISTERED_TOOL_NAMES))
         logger.info("=" * 60)
 
-        # Use FastMCP's built-in stdio transport
-        mcp.run()
+        transport = (args.transport or "stdio").strip().lower()
+        if transport == "http":
+            transport = "streamable-http"
+
+        run_kwargs: Dict[str, Any] = {"show_banner": False}
+        if transport in {"streamable-http", "sse"}:
+            run_kwargs.update({
+                "host": args.host,
+                "port": args.port,
+                "stateless_http": args.stateless_http,
+            })
+            if transport == "streamable-http":
+                run_kwargs["path"] = args.http_path
+
+        logger.info("Starting FastMCP transport=%s", transport)
+        mcp.run(transport=transport, **run_kwargs)
     except (RuntimeError, OSError, ImportError) as e:
         logger.error("[ERROR] Failed to start server: %s", e)
 

--- a/mcp_kql_server/memory.py
+++ b/mcp_kql_server/memory.py
@@ -22,12 +22,29 @@ from dataclasses import dataclass
 from datetime import datetime
 import numpy as np
 
-try:
-    from sentence_transformers import SentenceTransformer
-    HAS_SENTENCE_TRANSFORMERS = True
-except ImportError:
-    SentenceTransformer = None
-    HAS_SENTENCE_TRANSFORMERS = False
+SentenceTransformer = None
+HAS_SENTENCE_TRANSFORMERS = False
+_SENTENCE_TRANSFORMERS_IMPORT_ATTEMPTED = False
+
+
+def _get_sentence_transformer_class():
+    """Import SentenceTransformer only when semantic embeddings are used."""
+    global SentenceTransformer, HAS_SENTENCE_TRANSFORMERS  # pylint: disable=global-statement
+    global _SENTENCE_TRANSFORMERS_IMPORT_ATTEMPTED  # pylint: disable=global-statement
+    if _SENTENCE_TRANSFORMERS_IMPORT_ATTEMPTED and not HAS_SENTENCE_TRANSFORMERS:
+        return None
+    if SentenceTransformer is not None:
+        return SentenceTransformer
+    _SENTENCE_TRANSFORMERS_IMPORT_ATTEMPTED = True
+    try:
+        from sentence_transformers import SentenceTransformer as _SentenceTransformer
+        SentenceTransformer = _SentenceTransformer
+        HAS_SENTENCE_TRANSFORMERS = True
+        return SentenceTransformer
+    except ImportError:
+        SentenceTransformer = None
+        HAS_SENTENCE_TRANSFORMERS = False
+        return None
 
 logger = logging.getLogger(__name__)
 
@@ -86,18 +103,18 @@ class SemanticSearch:
 
     def preload(self):
         """Preload model in background thread for faster first query."""
-        if self.model is None and not self._loading and HAS_SENTENCE_TRANSFORMERS:
+        if self.model is None and not self._loading and _get_sentence_transformer_class():
             threading.Thread(target=self._load_model, daemon=True).start()
 
     def _load_model(self):
         """Thread-safe lazy load of the model."""
         with self._load_lock:
-            if self.model is None and HAS_SENTENCE_TRANSFORMERS:
+            transformer_cls = _get_sentence_transformer_class()
+            if self.model is None and transformer_cls:
                 self._loading = True
                 try:
                     logging.getLogger('sentence_transformers').setLevel(logging.WARNING)
-                    if SentenceTransformer:
-                        self.model = SentenceTransformer(self.model_name)
+                    self.model = transformer_cls(self.model_name)
                     logger.info("Loaded Semantic Search model: %s", self.model_name)
                 except (OSError, RuntimeError, ValueError) as e:
                     logger.warning("Failed to load SentenceTransformer: %s", e)
@@ -158,9 +175,18 @@ class MemoryManager:
         base_dir.mkdir(parents=True, exist_ok=True)
         return base_dir / "kql_memory.db"
 
+    def _connect(self) -> sqlite3.Connection:
+        """Open a SQLite connection tuned for concurrent MCP instances."""
+        busy_timeout_ms = int(os.environ.get("MCP_KQL_SQLITE_BUSY_TIMEOUT_MS", "30000"))
+        conn = sqlite3.connect(self.db_path, timeout=busy_timeout_ms / 1000)
+        conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
     def _init_db(self):
         """Initialize SQLite database schema."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             # Enable WAL mode for better concurrency
             conn.execute("PRAGMA journal_mode=WAL")
 
@@ -303,7 +329,7 @@ class MemoryManager:
                     normalized_cols[col] = {"data_type": "string"}
             columns = normalized_cols
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             # Check if columns exist (migration for existing DBs)
             try:
                 conn.execute("ALTER TABLE schemas ADD COLUMN embedding BLOB")
@@ -350,7 +376,7 @@ class MemoryManager:
         col_names = " ".join(columns.keys())
         embedding = self.semantic_search.encode(f"Table {table} contains columns: {col_names}")
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
 
             conn.execute("""
                 INSERT OR REPLACE INTO schemas
@@ -371,7 +397,7 @@ class MemoryManager:
         normalized_cluster = self.normalize_cluster_uri(cluster)
         embedding = self.semantic_search.encode(f"{description} {query}")
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             # Check for new column (migration)
             try:
                 conn.execute("ALTER TABLE queries ADD COLUMN execution_time_ms REAL")
@@ -393,7 +419,7 @@ class MemoryManager:
     def store_learning_result(self, query: str, result_data: Dict[str, Any],
                               execution_type: str, execution_time_ms: float = 0.0):
         """Store learning result from query execution."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             # Check for new column (migration)
             try:
                 conn.execute("ALTER TABLE learning_events ADD COLUMN execution_time_ms REAL")
@@ -418,7 +444,7 @@ class MemoryManager:
         query_vector = np.frombuffer(query_embedding, dtype=np.float32)
         results = []
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(
                 "SELECT table_name, columns_json, embedding FROM schemas WHERE cluster = ? AND database = ?",
                 (normalized_cluster, database)
@@ -452,7 +478,7 @@ class MemoryManager:
         query_vector = np.frombuffer(query_embedding, dtype=np.float32)
         results = []
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(
                 "SELECT query, description, embedding FROM queries WHERE cluster = ? AND database = ?",
                 (normalized_cluster, database)
@@ -806,7 +832,7 @@ class MemoryManager:
         effective_ttl = ttl_map.get(query_type, ttl_seconds)
         normalized_cluster = self.normalize_cluster_uri(cluster or "") if cluster else None
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             conn.execute("""
                 INSERT OR REPLACE INTO query_cache 
                 (query_hash, result_json, timestamp, row_count, query_type, ttl_seconds, cluster, database)
@@ -839,7 +865,7 @@ class MemoryManager:
             cache_namespace=cache_namespace,
         )
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(
                 "SELECT result_json, timestamp, ttl_seconds FROM query_cache WHERE query_hash = ?",
                 (query_hash,)
@@ -873,7 +899,7 @@ class MemoryManager:
         if clauses:
             delete_sql += " WHERE " + " AND ".join(clauses)
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(delete_sql, params)
             removed = cursor.rowcount
             conn.commit()
@@ -882,7 +908,7 @@ class MemoryManager:
 
     def get_cache_stats(self) -> Dict[str, Any]:
         """Get detailed cache statistics."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             total = conn.execute("SELECT COUNT(*) FROM query_cache").fetchone()[0]
             by_type = {}
             cursor = conn.execute(
@@ -905,7 +931,7 @@ class MemoryManager:
 
     def cleanup_expired_cache(self) -> int:
         """Remove expired cache entries and return count of removed entries."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute("""
                 DELETE FROM query_cache 
                 WHERE (julianday('now') - julianday(timestamp)) * 86400 > COALESCE(ttl_seconds, 300)
@@ -917,7 +943,7 @@ class MemoryManager:
 
     def store_join_hint(self, table1: str, table2: str, condition: str):
         """Store a discovered join relationship."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             conn.execute("""
                 INSERT OR REPLACE INTO join_hints (table1, table2, join_condition, confidence, last_used)
                 VALUES (?, ?, ?, 1.0, ?)
@@ -937,7 +963,7 @@ class MemoryManager:
             "SELECT table1, table2, join_condition FROM join_hints "
             f"WHERE table1 IN ({placeholders}) OR table2 IN ({placeholders})"
         )
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(query, tables + tables)
             for row in cursor:
                 hints.append(f"{row[0]} joins with {row[1]} on {row[2]}")
@@ -953,7 +979,7 @@ class MemoryManager:
             if (datetime.now() - cached['ts']).seconds < 300:  # 5 min TTL
                 return cached['data']
 
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(
                 "SELECT table_name, columns_json FROM schemas WHERE cluster = ? AND database = ?",
                 (normalized_cluster, database)
@@ -1036,7 +1062,7 @@ class MemoryManager:
     def clear_memory(self) -> bool:
         """Clear all data from the database."""
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 conn.execute("DELETE FROM schemas")
                 conn.execute("DELETE FROM queries")
                 conn.execute("DELETE FROM query_cache")
@@ -1059,7 +1085,7 @@ class MemoryManager:
 
     def get_memory_stats(self) -> Dict[str, Any]:
         """Get statistics about the memory database including cache stats."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             schema_count = conn.execute("SELECT COUNT(*) FROM schemas").fetchone()[0]
             query_count = conn.execute("SELECT COUNT(*) FROM queries").fetchone()[0]
             learning_count = 0
@@ -1100,7 +1126,7 @@ class MemoryManager:
 
     def get_performance_metrics(self) -> Dict[str, Any]:
         """Get performance metrics (execution time, success rate)."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             # Average execution time
             try:
                 avg_time = conn.execute(
@@ -1120,7 +1146,7 @@ class MemoryManager:
 
     def get_recent_queries(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Get recent successful queries."""
-        with self._lock, sqlite3.connect(self.db_path) as conn:
+        with self._lock, self._connect() as conn:
             cursor = conn.execute(
                 "SELECT query, description, cluster, database, timestamp FROM queries ORDER BY id DESC LIMIT ?",
                 (limit,)
@@ -1213,7 +1239,7 @@ class MemoryManager:
             True if registered successfully, False otherwise
         """
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 conn.execute(
                     """
                     INSERT OR REPLACE INTO table_locations 
@@ -1239,7 +1265,7 @@ class MemoryManager:
             List of dicts with 'cluster', 'database', 'last_seen' keys
         """
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 cursor = conn.execute(
                     """
                     SELECT cluster, database, last_seen 
@@ -1268,7 +1294,7 @@ class MemoryManager:
             True if table is found in more than one cluster
         """
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 cursor = conn.execute(
                     """
                     SELECT COUNT(DISTINCT cluster) 
@@ -1291,7 +1317,7 @@ class MemoryManager:
             Dict mapping table names to lists of location dicts
         """
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 cursor = conn.execute(
                     """
                     SELECT table_name, cluster, database, last_seen 
@@ -1329,7 +1355,7 @@ class MemoryManager:
             True if removed successfully
         """
         try:
-            with self._lock, sqlite3.connect(self.db_path) as conn:
+            with self._lock, self._connect() as conn:
                 conn.execute(
                     """
                     DELETE FROM table_locations 

--- a/mcp_kql_server/memory.py
+++ b/mcp_kql_server/memory.py
@@ -8,6 +8,7 @@ This module provides a high-performance memory system that:
 - Supports Semantic Search (using sentence-transformers) for Few-Shot prompting.
 
 Author: Arjun Trivedi
+Email: arjuntrivedi42@yahoo.com
 """
 
 import sqlite3

--- a/mcp_kql_server/performance.py
+++ b/mcp_kql_server/performance.py
@@ -9,7 +9,7 @@ This module provides:
 - Health monitoring for connections
 
 Author: Arjun Trivedi
-Version: 2.1.1
+Email: arjuntrivedi42@yahoo.com
 """
 
 import asyncio

--- a/mcp_kql_server/utils.py
+++ b/mcp_kql_server/utils.py
@@ -17,6 +17,9 @@ Functions implemented here:
  - validate_all_query_columns
  - fix_query_with_real_schema
  - generate_query_description
+
+Author: Arjun Trivedi
+Email: arjuntrivedi42@yahoo.com
 """
 import asyncio
 import difflib
@@ -33,6 +36,76 @@ from .constants import KQL_RESERVED_WORDS
 
 # Set up logger at module level
 logger = logging.getLogger(__name__)
+
+# Patterns for credentials that must never reach logs. KQL queries normally do
+# not embed secrets (auth is delegated to the Azure credential chain), but a
+# user could paste an inline connection string or token. Redact defensively.
+_SECRET_PATTERNS = [
+    # user:password@host inside a connection/cluster string
+    (re.compile(r'(://[^/\s:]+:)([^@/\s]+)(@)'), r'\1***\3'),
+    # bare bearer/JWT-like tokens (run before the key=value rule so the token
+    # after "Authorization: Bearer" is masked rather than just the word "Bearer")
+    (re.compile(r'(?i)\bbearer\s+[A-Za-z0-9._\-]+'), 'bearer ***'),
+    # key=value style secrets (password, secret, token, apikey, pwd, sig, etc.)
+    (re.compile(
+        r'(?i)\b(password|pwd|secret|token|api[_-]?key|client[_-]?secret|sig|signature|authorization)'
+        r'(\s*[=:]\s*)("?)([^\s"&;,)]+)(\3)'
+    ), r'\1\2\3***\5'),
+]
+
+
+def redact_secrets(text: Optional[str]) -> str:
+    """Mask credentials in text before it is written to logs.
+
+    Conservative by design: it only masks values that match well-known secret
+    patterns and leaves ordinary query text intact so logs stay useful for
+    debugging. Returns an empty string for ``None``.
+    """
+    if not text:
+        return ""
+    redacted = str(text)
+    for pattern, replacement in _SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+# Canonical KQL/CSL scalar types. Schema discovery can surface a column's type
+# as a CSL type ("datetime"), a .NET type ("System.Int64"), or an inferred
+# guess. Downstream NL2KQL generation keys off canonical lowercase KQL types
+# (it only builds time filters for "datetime" columns, groups/filters on
+# "string"/"guid", etc.), so every ingestion path must collapse to one vocabulary.
+_KQL_TYPE_ALIASES = {
+    "system.datetime": "datetime", "datetime": "datetime", "date": "datetime",
+    "system.string": "string", "string": "string", "text": "string",
+    "system.boolean": "bool", "boolean": "bool", "bool": "bool", "system.sbyte": "bool",
+    "system.int16": "int", "int16": "int", "system.int32": "int", "int32": "int", "int": "int",
+    "system.int64": "long", "int64": "long", "long": "long",
+    "system.single": "real", "single": "real", "float": "real",
+    "system.double": "real", "double": "real", "real": "real",
+    "system.decimal": "decimal", "decimal": "decimal",
+    "system.guid": "guid", "guid": "guid", "uuid": "guid",
+    "system.timespan": "timespan", "timespan": "timespan",
+    "system.object": "dynamic", "object": "dynamic", "dynamic": "dynamic", "array": "dynamic",
+}
+
+
+def normalize_kql_type(raw_type: Any) -> str:
+    """Normalize a CSL/.NET/inferred column type to a canonical lowercase KQL type.
+
+    Schema discovery may report a type as a CSL type ("datetime"), a .NET type
+    ("System.Int64"), or an inferred guess. NL2KQL generation only reasons about
+    canonical KQL types, so collapse every spelling to one vocabulary
+    (datetime, string, bool, int, long, real, decimal, guid, timespan, dynamic).
+    Unknown types fall through as a cleaned lowercase string instead of guessing.
+    """
+    if not raw_type:
+        return "string"
+    key = str(raw_type).strip().lower()
+    if key in _KQL_TYPE_ALIASES:
+        return _KQL_TYPE_ALIASES[key]
+    stripped = key.replace("system.", "")
+    return _KQL_TYPE_ALIASES.get(stripped, stripped or "string")
+
 
 def _is_retryable_exc(e: BaseException) -> bool:
     """Lightweight check for retryable transport-class exceptions.
@@ -418,7 +491,7 @@ class SchemaManager:
                             logger.debug("Successfully executed query on attempt %s", attempt + 1)
                             return data
                         else:
-                            logger.warning("Query returned no results: %s", query)
+                            logger.warning("Query returned no results: %s", redact_secrets(query))
                             return []
 
                 except (OSError, RuntimeError, ValueError, TimeoutError) as e:
@@ -430,7 +503,7 @@ class SchemaManager:
 
                     # Check if this is the final attempt
                     if attempt >= max_retries:
-                        logger.error("All retry attempts exhausted for query: %s", query)
+                        logger.error("All retry attempts exhausted for query: %s", redact_secrets(query))
                         break
 
                     # Check if error is retryable
@@ -672,7 +745,7 @@ class SchemaManager:
                     columns = {}
                     for col in schema_json.get('Schema', {}).get('OrderedColumns', []):
                         col_name = col['Name']
-                        col_type = col['CslType']
+                        col_type = normalize_kql_type(col.get('CslType') or col.get('ColumnType') or col.get('DataType'))
                         sample_values = sample_data.get(col_name, [])
                         columns[col_name] = {
                             'data_type': col_type,
@@ -716,10 +789,11 @@ class SchemaManager:
                     columns = {}
                     for i, row in enumerate(getschema_result):
                         col_name = row.get('ColumnName') or row.get('Column') or f'Column{i}'
-                        col_type = row.get('DataType') or row.get('ColumnType') or 'string'
-
-                        # Clean up data type
-                        col_type = str(col_type).replace('System.', '').lower()
+                        # Prefer the CSL/KQL type (ColumnType) over the .NET DataType
+                        # so the canonical KQL type (e.g. "long") is stored, not "Int64".
+                        col_type = normalize_kql_type(
+                            row.get('ColumnType') or row.get('DataType') or 'string'
+                        )
 
                         sample_values = sample_data.get(col_name, [])
                         columns[col_name] = {
@@ -875,10 +949,11 @@ class SchemaManager:
             if not col_name:
                 continue
 
-            # Extract accurate data type from DataType column
-            data_type = str(row.get('DataType', 'unknown')).replace("System.", "")
-            if data_type == "unknown" and row.get('ColumnType'):
-                data_type = str(row.get('ColumnType', 'unknown'))
+            # Extract the canonical KQL type, preferring the CSL ColumnType over
+            # the .NET DataType so generation sees "long"/"datetime", not "Int64".
+            data_type = normalize_kql_type(
+                row.get('ColumnType') or row.get('DataType') or row.get('CslType')
+            )
 
             # Extract sample values from sample data (limit to 3)
             sample_values = self._extract_sample_values_from_data(col_name, sample_data)
@@ -1655,6 +1730,8 @@ __all__ = [
     "extract_cluster_and_database_from_query",
     "extract_tables_from_query",
     "parse_query_entities",
+    "redact_secrets",
+    "normalize_kql_type",
 ]
 
 def extract_cluster_and_database_from_query(query: str) -> Tuple[Optional[str], Optional[str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-kql-server"
-version = "2.1.2"
+version = "2.1.3"
 description = "AI-Powered MCP server for KQL query execution with Natural Language to KQL (NL2KQL) conversion, intelligent schema memory, RAG-enhanced context assistance, and semantic search capabilities"
 authors = [{ name = "Arjun Trivedi", email = "arjuntrivedi42@yahoo.com" }]
 readme = "README.md"
@@ -37,7 +37,7 @@ dependencies = [
     "pydantic>=2.0.0,<3.0.0",
     "typing-extensions>=4.0.0,<5.0.0",
     "tabulate>=0.9.0,<1.0.0",
-    "fastmcp>=2.14.7,<3.0.0",
+    "fastmcp>=2.14.7,<4.0.0",
     "azure-kusto-data>=4.0.0,<6.0.0",
     "azure-identity>=1.15.0,<2.0.0",
     "authlib>=1.3.0,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-kql-server"
-version = "2.1.3"
+version = "2.1.4"
 description = "AI-Powered MCP server for KQL query execution with Natural Language to KQL (NL2KQL) conversion, intelligent schema memory, RAG-enhanced context assistance, and semantic search capabilities"
 authors = [{ name = "Arjun Trivedi", email = "arjuntrivedi42@yahoo.com" }]
 readme = "README.md"
@@ -40,7 +40,6 @@ dependencies = [
     "fastmcp>=2.14.7,<4.0.0",
     "azure-kusto-data>=4.0.0,<6.0.0",
     "azure-identity>=1.15.0,<2.0.0",
-    "authlib>=1.3.0,<2.0.0",
     "azure-core>=1.30.0,<2.0.0",
     "httpx>=0.25.0,<1.0.0",
     "requests>=2.31.0,<3.0.0",
@@ -49,9 +48,8 @@ dependencies = [
     "colorama>=0.4.6,<1.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "sentence-transformers>=2.0.0,<6.0.0",
-    "scikit-learn>=1.0.0,<2.0.0",
     "numpy>=1.21.0,<3.0.0",
-    "pandas",
+    "pandas>=1.3.0,<3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,11 @@ typing-extensions>=4.0.0,<5.0.0
 # Azure Kusto (KQL) Integration
 azure-kusto-data>=4.0.0,<6.0.0
 azure-identity>=1.15.0,<2.0.0
-authlib>=1.3.0,<2.0.0
 azure-core>=1.30.0,<2.0.0
 
 # Data Handling and AI/ML
-pandas
+pandas>=1.3.0,<3.0.0
 sentence-transformers>=2.0.0,<6.0.0
-scikit-learn>=1.0.0,<2.0.0
 numpy>=1.21.0,<3.0.0
 
 # Networking and HTTP

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # MCP KQL Server Dependencies
 
 # Core MCP Framework
-fastmcp>=2.10.0,<3.0.0
+fastmcp>=2.14.7,<4.0.0
 pydantic>=2.0.0,<3.0.0
 typing-extensions>=4.0.0,<5.0.0
 

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.4R9UN/mcp-kql-server",
   "title": "MCP KQL Server",
   "description": "Execute KQL in AI prompts via NL2KQL with schema discovery and Azure Data Explorer integration",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-kql-server",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "transport": {
         "type": "stdio",
         "command": "python",

--- a/server.json
+++ b/server.json
@@ -3,16 +3,19 @@
   "name": "io.github.4R9UN/mcp-kql-server",
   "title": "MCP KQL Server",
   "description": "Execute KQL in AI prompts via NL2KQL with schema discovery and Azure Data Explorer integration",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-kql-server",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "transport": {
         "type": "stdio",
         "command": "python",
-        "args": ["-m", "mcp_kql_server"]
+        "args": [
+          "-m",
+          "mcp_kql_server"
+        ]
       }
     }
   ]

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,18 +5,25 @@ Author: Arjun Trivedi
 Email: arjuntrivedi42@yahoo.com
 """
 
+import asyncio
+import inspect
+
 from mcp_kql_server.constants import (
     DEFAULT_CONNECTION_TIMEOUT,
     DEFAULT_QUERY_TIMEOUT,
     LIMITS,
+    REGISTERED_TOOL_NAMES,
     SERVER_NAME,
+    TOOL_KQL_EXECUTE_NAME,
+    TOOL_KQL_SCHEMA_NAME,
     __version__,
+    format_display_path,
 )
 
 
 def test_version_constants():
     """Test version constants are properly defined."""
-    assert __version__ == "2.1.2"
+    assert __version__ == "2.1.3"
 
 
 def test_server_constants():
@@ -31,3 +38,37 @@ def test_limits():
     assert isinstance(LIMITS, dict)
     assert "max_result_rows" in LIMITS
     assert LIMITS["max_result_rows"] > 0
+
+
+def test_format_display_path_redacts_appdata(monkeypatch):
+    """Test user-facing paths use environment variable placeholders."""
+    monkeypatch.setenv("APPDATA", r"C:\Users\example\AppData\Roaming")
+
+    display_path = format_display_path(r"C:\Users\example\AppData\Roaming\KQL_MCP\kql_memory.db")
+
+    assert display_path == r"%APPDATA%\KQL_MCP\kql_memory.db"
+    assert "C:\\Users\\example" not in display_path
+
+
+def test_registered_tool_name_constants_match_fastmcp_registry():
+    """Test documented tool names match the FastMCP registry."""
+    from mcp_kql_server.mcp_server import mcp
+
+    if hasattr(mcp, "get_tools"):
+        registered_tool_names = set(asyncio.run(mcp.get_tools()))
+    elif hasattr(mcp, "get_tool"):
+        registered_tool_names = set()
+        for tool_name in REGISTERED_TOOL_NAMES:
+            tool = mcp.get_tool(tool_name)
+            if inspect.isawaitable(tool):
+                tool = asyncio.run(tool)
+            if tool is not None:
+                registered_tool_names.add(tool_name)
+    else:
+        registry = getattr(mcp, "_tool_manager", None) or getattr(mcp, "tool_manager", None)
+        tool_map = getattr(registry, "_tools", {}) if registry else {}
+        registered_tool_names = set(tool_map)
+
+    assert TOOL_KQL_EXECUTE_NAME == "execute_kql_query"
+    assert TOOL_KQL_SCHEMA_NAME == "kql_schema_memory"
+    assert set(REGISTERED_TOOL_NAMES).issubset(registered_tool_names)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -23,7 +23,7 @@ from mcp_kql_server.constants import (
 
 def test_version_constants():
     """Test version constants are properly defined."""
-    assert __version__ == "2.1.3"
+    assert __version__ == "2.1.4"
 
 
 def test_server_constants():

--- a/tests/test_generation_pipeline.py
+++ b/tests/test_generation_pipeline.py
@@ -248,7 +248,8 @@ async def test_execute_kql_query_repairs_invalid_time_column():
         })
         mocked_validator.validate_query = AsyncMock(side_effect=validation_results)
 
-        result = await mcp_server.execute_kql_query.fn(
+        execute_fn = getattr(mcp_server.execute_kql_query, "fn", mcp_server.execute_kql_query)
+        result = await execute_fn(
             query="MtpAlertEvidence | where AlertId == \"abc\" | order by Timestamp asc",
             cluster_url="cluster",
             database="db",

--- a/tests/test_kql_auth.py
+++ b/tests/test_kql_auth.py
@@ -127,6 +127,21 @@ class TestKQLAuth(unittest.TestCase):
 
     @patch("mcp_kql_server.kql_auth.trigger_az_cli_auth")
     @patch("mcp_kql_server.kql_auth.kql_auth")
+    def test_authenticate_non_interactive_does_not_login(self, mock_kql_auth, mock_trigger_auth):
+        """Test non-interactive auth check never starts device-code login."""
+        mock_kql_auth.return_value = {
+            "authenticated": False,
+            "message": "Not authenticated",
+        }
+
+        result = authenticate(interactive=False)
+
+        self.assertFalse(result["authenticated"])
+        self.assertTrue(result["interactive_required"])
+        mock_trigger_auth.assert_not_called()
+
+    @patch("mcp_kql_server.kql_auth.trigger_az_cli_auth")
+    @patch("mcp_kql_server.kql_auth.kql_auth")
     def test_authenticate_login_fails(self, mock_kql_auth, mock_trigger_auth):
         """Test authenticate when login fails."""
         # Mock not authenticated initially

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -112,6 +112,51 @@ class TestMCPServerFunctions(unittest.TestCase):
         # Note: clear_schema_cache is available via SchemaManager, not directly on memory manager
         self.assertTrue(hasattr(manager, 'corpus') or hasattr(manager, 'memory_path'))
 
+    @patch("sys.argv", ["mcp-kql-server"])
+    @patch("mcp_kql_server.version_checker.startup_version_check")
+    @patch("mcp_kql_server.mcp_server.mcp.run")
+    @patch("mcp_kql_server.mcp_server.authenticate_kusto")
+    def test_main_defers_auth_and_update_check(
+            self, mock_authenticate, mock_run, mock_version_check):
+        """Test default startup avoids blocking auth and PyPI update checks."""
+        from mcp_kql_server.mcp_server import main
+
+        main()
+
+        mock_authenticate.assert_not_called()
+        mock_version_check.assert_not_called()
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args.kwargs["transport"], "stdio")
+
+    @patch(
+        "sys.argv",
+        [
+            "mcp-kql-server",
+            "--transport", "http",
+            "--port", "8123",
+            "--http-path", "/kql",
+            "--stateless-http",
+        ],
+    )
+    @patch("mcp_kql_server.version_checker.startup_version_check")
+    @patch("mcp_kql_server.mcp_server.mcp.run")
+    @patch("mcp_kql_server.mcp_server.authenticate_kusto")
+    def test_main_configures_streamable_http_transport(
+            self, mock_authenticate, mock_run, mock_version_check):
+        """Test shared HTTP mode passes v3-compatible transport settings to FastMCP."""
+        from mcp_kql_server.mcp_server import main
+
+        main()
+
+        mock_authenticate.assert_not_called()
+        mock_version_check.assert_not_called()
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        self.assertEqual(kwargs["transport"], "streamable-http")
+        self.assertEqual(kwargs["port"], 8123)
+        self.assertEqual(kwargs["path"], "/kql")
+        self.assertTrue(kwargs["stateless_http"])
+
 
     @pytest.mark.skip(reason="_execute_kql_query_logic was refactored into execute_kql_query")
     @patch("mcp_kql_server.mcp_server.kql_execute_tool")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,13 +16,13 @@ def test_package_imports():
     """Test that package imports work correctly."""
     assert hasattr(mcp_kql_server, "__version__")
     assert hasattr(mcp_kql_server, "__author__")
-    assert mcp_kql_server.__version__ == "2.1.2"
+    assert mcp_kql_server.__version__ == "2.1.3"
     assert mcp_kql_server.__author__ == "Arjun Trivedi"
 
 
 def test_version_consistency():
     """Test that version is consistent across modules."""
-    assert pkg_version == const_version == "2.1.2"
+    assert pkg_version == const_version == "2.1.3"
 
 
 def test_author_attribution():

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,13 +16,13 @@ def test_package_imports():
     """Test that package imports work correctly."""
     assert hasattr(mcp_kql_server, "__version__")
     assert hasattr(mcp_kql_server, "__author__")
-    assert mcp_kql_server.__version__ == "2.1.3"
+    assert mcp_kql_server.__version__ == "2.1.4"
     assert mcp_kql_server.__author__ == "Arjun Trivedi"
 
 
 def test_version_consistency():
     """Test that version is consistent across modules."""
-    assert pkg_version == const_version == "2.1.3"
+    assert pkg_version == const_version == "2.1.4"
 
 
 def test_author_attribution():


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Version bump to 2.1.3 with FastMCP v2 and v3 compatibility, faster startup via lazy imports and deferred auth, and SQLite concurrency hardening for multiple local MCP instances.</li>
<li>Renamed 'schema_memory' tool to 'kql_schema_memory' and added shared HTTP transport support for multi-client deployments.</li>
<li>Updated documentation with simplified README, new runtime settings table, and improved MCP configuration examples.</li>
<li>Added new CLI options and environment variables for transport modes, auth timeouts, and update checks.</li>
</ul></div>